### PR TITLE
feat: Relatório P1A — nova tela e API com as 3 visões do workbook P1A

### DIFF
--- a/api/relatorio-p1a.js
+++ b/api/relatorio-p1a.js
@@ -1,0 +1,16 @@
+const handlers = {
+  options: require('../handlers/relatorio-p1a-options'),
+  refresh: require('../handlers/relatorio-p1a-refresh'),
+  colmeia: require('../handlers/relatorio-p1a-colmeia'),
+  exibidor: require('../handlers/relatorio-p1a-exibidor'),
+  modelo: require('../handlers/relatorio-p1a-modelo'),
+};
+
+module.exports = async (req, res) => {
+  const action = req.query.action || 'options';
+  const handler = handlers[action];
+  if (!handler) {
+    return res.status(400).json({ error: `Action '${action}' not found` });
+  }
+  return handler(req, res);
+};

--- a/handlers/relatorio-p1a-colmeia.js
+++ b/handlers/relatorio-p1a-colmeia.js
@@ -1,0 +1,49 @@
+/**
+ * POST /api/relatorio-p1a-colmeia
+ *
+ * Aba "Colmeia" do Relatório P1A — matriz métrica × semana, agrupada
+ * por dimensão (GEO | PRACA | UF). Executa
+ * `sp_reportResultColmeiaGeoClosed` (a SP é única e aceita a dimensão
+ * como parâmetro, conforme padrão do parceiro).
+ *
+ * Body:
+ *   { reportPks, dimension?: 'GEO' | 'PRACA' | 'UF', dimensionValue?: string }
+ */
+const { sql, getPool } = require('./db');
+const {
+  extractReportPksCsv,
+  normalizeDimension,
+} = require('./relatorio-p1a-utils');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const { csv, error } = extractReportPksCsv(req.body);
+    if (error) return res.status(400).json({ error });
+
+    const dimension = normalizeDimension(req.body?.dimension, 'GEO');
+    const dimensionValue = req.body?.dimensionValue || null;
+
+    const pool = await getPool();
+    const request = pool.request()
+      .input('planoMidiaGrupoPk_st', sql.NVarChar(sql.MAX), csv)
+      .input('dimension_st', sql.NVarChar(20), dimension)
+      .input('dimensionValue_st', sql.NVarChar(255), dimensionValue);
+
+    console.log(`🔄 [relatorio-p1a-colmeia] pks=${csv} dim=${dimension} value=${dimensionValue ?? '(todas)'}`);
+
+    const result = await request.execute('[serv_product_be180].[sp_reportResultColmeiaGeoClosed]');
+
+    return res.status(200).json({
+      rows: result.recordset || [],
+      dimension,
+      dimensionValue,
+    });
+  } catch (err) {
+    console.error('❌ [relatorio-p1a-colmeia] Erro:', err);
+    return res.status(500).json({ error: err.message || 'Erro ao calcular aba Colmeia' });
+  }
+};

--- a/handlers/relatorio-p1a-exibidor.js
+++ b/handlers/relatorio-p1a-exibidor.js
@@ -1,0 +1,66 @@
+/**
+ * POST /api/relatorio-p1a-exibidor
+ *
+ * Aba "Exibidor" do Relatório P1A — TOTAL agregado + bloco por exibidor.
+ * Mapeia a dimensão para a SP "Closed" correspondente:
+ *   GEO   → sp_reportResultExibidorGeoClosed
+ *   PRACA → sp_reportResultExibidorPracaClosed
+ *   UF    → sp_reportResultExibidorUfClosed
+ *
+ * Body:
+ *   { reportPks, dimension: 'GEO' | 'PRACA' | 'UF',
+ *     dimensionValue?, marca?, negociacao? }
+ */
+const { sql, getPool } = require('./db');
+const {
+  extractReportPksCsv,
+  normalizeDimension,
+  normalizeNegociacao,
+} = require('./relatorio-p1a-utils');
+
+const SP_BY_DIMENSION = {
+  GEO: '[serv_product_be180].[sp_reportResultExibidorGeoClosed]',
+  PRACA: '[serv_product_be180].[sp_reportResultExibidorPracaClosed]',
+  UF: '[serv_product_be180].[sp_reportResultExibidorUfClosed]',
+};
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const { csv, error } = extractReportPksCsv(req.body);
+    if (error) return res.status(400).json({ error });
+
+    const dimension = normalizeDimension(req.body?.dimension, 'GEO');
+    const dimensionValue = req.body?.dimensionValue || null;
+    const marca = req.body?.marca || null;
+    const negociacao = normalizeNegociacao(req.body?.negociacao);
+
+    const spName = SP_BY_DIMENSION[dimension];
+    const pool = await getPool();
+    const request = pool.request()
+      .input('planoMidiaGrupoPk_st', sql.NVarChar(sql.MAX), csv)
+      .input('dimensionValue_st', sql.NVarChar(255), dimensionValue)
+      .input('marca_st', sql.NVarChar(255), marca)
+      .input('negociacao_st', sql.NVarChar(40), negociacao);
+
+    console.log(
+      `🔄 [relatorio-p1a-exibidor] pks=${csv} dim=${dimension} value=${dimensionValue ?? '(todas)'} marca=${marca ?? '(todas)'} neg=${negociacao}`,
+    );
+
+    const result = await request.execute(spName);
+
+    return res.status(200).json({
+      rows: result.recordset || [],
+      dimension,
+      dimensionValue,
+      marca,
+      negociacao,
+    });
+  } catch (err) {
+    console.error('❌ [relatorio-p1a-exibidor] Erro:', err);
+    return res.status(500).json({ error: err.message || 'Erro ao calcular aba Exibidor' });
+  }
+};

--- a/handlers/relatorio-p1a-modelo.js
+++ b/handlers/relatorio-p1a-modelo.js
@@ -1,0 +1,58 @@
+/**
+ * POST /api/relatorio-p1a-modelo
+ *
+ * Aba "Modelo P1A" — saída plana da SP `sp_reportResultP1aBase`. O pivot
+ * (week × exibidor × 6 métricas) é feito no cliente para preservar
+ * flexibilidade de filtros/exibição.
+ *
+ * Body:
+ *   { reportPks, dimension: 'GEO' | 'PRACA' | 'UF',
+ *     dimensionValue?, marca?, negociacao? }
+ */
+const { sql, getPool } = require('./db');
+const {
+  extractReportPksCsv,
+  normalizeDimension,
+  normalizeNegociacao,
+} = require('./relatorio-p1a-utils');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const { csv, error } = extractReportPksCsv(req.body);
+    if (error) return res.status(400).json({ error });
+
+    const dimension = normalizeDimension(req.body?.dimension, 'GEO');
+    const dimensionValue = req.body?.dimensionValue || null;
+    const marca = req.body?.marca || null;
+    const negociacao = normalizeNegociacao(req.body?.negociacao);
+
+    const pool = await getPool();
+    const request = pool.request()
+      .input('planoMidiaGrupoPk_st', sql.NVarChar(sql.MAX), csv)
+      .input('dimension_st', sql.NVarChar(20), dimension)
+      .input('dimensionValue_st', sql.NVarChar(255), dimensionValue)
+      .input('marca_st', sql.NVarChar(255), marca)
+      .input('negociacao_st', sql.NVarChar(40), negociacao);
+
+    console.log(
+      `🔄 [relatorio-p1a-modelo] pks=${csv} dim=${dimension} value=${dimensionValue ?? '(todas)'} marca=${marca ?? '(todas)'} neg=${negociacao}`,
+    );
+
+    const result = await request.execute('[serv_product_be180].[sp_reportResultP1aBase]');
+
+    return res.status(200).json({
+      rows: result.recordset || [],
+      dimension,
+      dimensionValue,
+      marca,
+      negociacao,
+    });
+  } catch (err) {
+    console.error('❌ [relatorio-p1a-modelo] Erro:', err);
+    return res.status(500).json({ error: err.message || 'Erro ao calcular aba Modelo P1A' });
+  }
+};

--- a/handlers/relatorio-p1a-options.js
+++ b/handlers/relatorio-p1a-options.js
@@ -1,0 +1,133 @@
+/**
+ * GET /api/relatorio-p1a-options
+ *
+ * Lista os roteiros (planoMidiaGrupo) elegíveis para o Relatório P1A.
+ * Quando `reportPks` é fornecido (querystring CSV), também devolve as
+ * opções escopadas (marcas, GEOs, praças, UFs, negociações) extraídas
+ * de reportDataP1aEmpilhamento_dm — útil para alimentar os filtros
+ * dependentes da seleção corrente.
+ *
+ * Respeita as regras de visibilidade do Colmeia:
+ *  - Usuário interno: vê todos os roteiros não deletados.
+ *  - Agência: vê apenas roteiros da própria agência liberados
+ *    (agencia_pk = empresa_pk AND liberadoAgencia_bl = 1).
+ */
+const { sql, getPool } = require('./db');
+const { normalizePks } = require('./relatorio-p1a-utils');
+
+const TOP_REPORTS = 200;
+
+async function listReports(pool, empresaPk) {
+  const req = pool.request();
+  let agenciaFilter = '';
+  if (empresaPk) {
+    req.input('empresaPk', sql.Int, empresaPk);
+    agenciaFilter = 'AND agencia_pk = @empresaPk AND liberadoAgencia_bl = 1';
+  }
+
+  const result = await req.query(`
+    SELECT TOP ${TOP_REPORTS}
+      planoMidiaGrupo_pk           AS _pk,
+      planoMidiaGrupo_pk,
+      planoMidiaGrupo_st,
+      planoMidiaDesc_st_concat,
+      usuarioId_st,
+      usuarioName_st,
+      gender_st,
+      class_st,
+      age_st,
+      planoMidiaType_st,
+      cidadeUpper_st_concat,
+      semanasMax_vl,
+      date_dh,
+      agencia_st,
+      liberadoAgencia_bl
+    FROM [serv_product_be180].[planoMidiaGrupo_dm_vw]
+    WHERE delete_bl = 0 ${agenciaFilter}
+    ORDER BY planoMidiaGrupo_pk DESC
+  `);
+
+  return result.recordset || [];
+}
+
+async function listScopedOptions(pool, csvPks) {
+  // Distinct de marcas, geos, cidades, ufs do stage empilhamento —
+  // escopado pelos reports selecionados. Os nomes refletem o schema
+  // real de [serv_product_be180].[reportDataP1aEmpilhamento_dm].
+  const req = pool.request().input('pks', sql.NVarChar(sql.MAX), csvPks);
+
+  const sqlText = `
+    DECLARE @t TABLE (report_pk INT);
+    INSERT INTO @t (report_pk)
+    SELECT TRY_CAST(value AS INT)
+    FROM STRING_SPLIT(@pks, ',')
+    WHERE TRY_CAST(value AS INT) IS NOT NULL;
+
+    SELECT DISTINCT marca_st
+    FROM [serv_product_be180].[reportDataP1aEmpilhamento_dm]
+    WHERE report_pk IN (SELECT report_pk FROM @t) AND marca_st IS NOT NULL
+    ORDER BY marca_st;
+
+    SELECT DISTINCT geoAmbev_st
+    FROM [serv_product_be180].[reportDataP1aEmpilhamento_dm]
+    WHERE report_pk IN (SELECT report_pk FROM @t) AND geoAmbev_st IS NOT NULL
+    ORDER BY geoAmbev_st;
+
+    SELECT DISTINCT cidade_st
+    FROM [serv_product_be180].[reportDataP1aEmpilhamento_dm]
+    WHERE report_pk IN (SELECT report_pk FROM @t) AND cidade_st IS NOT NULL
+    ORDER BY cidade_st;
+
+    SELECT DISTINCT estado_st
+    FROM [serv_product_be180].[reportDataP1aEmpilhamento_dm]
+    WHERE report_pk IN (SELECT report_pk FROM @t) AND estado_st IS NOT NULL
+    ORDER BY estado_st;
+  `;
+
+  const result = await req.query(sqlText);
+  const recordsets = result.recordsets || [];
+  const marcas = (recordsets[0] || []).map((r) => r.marca_st);
+  const geos = (recordsets[1] || []).map((r) => r.geoAmbev_st);
+  const pracas = (recordsets[2] || []).map((r) => r.cidade_st);
+  const ufs = (recordsets[3] || []).map((r) => r.estado_st);
+
+  return {
+    marcas,
+    dimensions: { GEO: geos, PRACA: pracas, UF: ufs },
+    negociacoes: ['TOTAL', 'FATURAVEL', 'NAO_FATURAVEL'],
+  };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const empresaPk = req.user?.empresa_pk ?? null;
+    const csvPks = normalizePks(req.query?.reportPks);
+    const pool = await getPool();
+
+    const reports = await listReports(pool, empresaPk);
+
+    let scoped = null;
+    if (csvPks) {
+      try {
+        scoped = await listScopedOptions(pool, csvPks);
+      } catch (err) {
+        console.error('⚠️ [relatorio-p1a-options] Erro ao buscar opções escopadas:', err.message);
+        // Não falha a requisição inteira — devolve só a lista de reports
+      }
+    }
+
+    return res.status(200).json({
+      reports,
+      marcas: scoped?.marcas ?? [],
+      dimensions: scoped?.dimensions ?? { GEO: [], PRACA: [], UF: [] },
+      negociacoes: scoped?.negociacoes ?? ['TOTAL', 'FATURAVEL', 'NAO_FATURAVEL'],
+    });
+  } catch (err) {
+    console.error('❌ [relatorio-p1a-options] Erro:', err);
+    return res.status(500).json({ error: err.message || 'Erro interno do servidor' });
+  }
+};

--- a/handlers/relatorio-p1a-refresh.js
+++ b/handlers/relatorio-p1a-refresh.js
@@ -1,0 +1,64 @@
+/**
+ * POST /api/relatorio-p1a-refresh
+ *
+ * Reconstrói a tabela de stage `reportDataP1aEmpilhamento_dm` para os
+ * roteiros selecionados, executando a stored procedure
+ * `serv_product_be180.sp_reportDataP1aEmpilhamentoRefresh`.
+ *
+ * Assinatura real da SP no schema serv_product_be180:
+ *   @planoMidiaGrupoPk_st          NVARCHAR(MAX)  -- CSV de PKs
+ *   @skipIfFresherThanMinutes_vl   INT            -- pula refresh se o stage
+ *                                                    foi atualizado dentro
+ *                                                    desse intervalo (0 = nunca pula)
+ *
+ * Mapeamento amigável aceito pelo body:
+ *   { reportPks, force?: boolean, ttlMinutes?: number }
+ *     - force=true       → @skipIfFresherThanMinutes_vl = 0 (sempre atualiza)
+ *     - ttlMinutes=N     → @skipIfFresherThanMinutes_vl = N
+ *     - nenhum dos dois  → parâmetro omitido (SP usa o default dela)
+ *
+ * Resposta:
+ *   { rows: [{ report_pk, refreshedAt_dh, rowsWritten_vl, skipped_bl, sourceType_st }] }
+ */
+const { sql, getPool } = require('./db');
+const { extractReportPksCsv } = require('./relatorio-p1a-utils');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const { csv, error } = extractReportPksCsv(req.body);
+    if (error) return res.status(400).json({ error });
+
+    const force = Boolean(req.body?.force ?? false);
+    const ttlMinutes = req.body?.ttlMinutes;
+
+    let skipIfFresherThanMinutes = null;
+    if (force) {
+      skipIfFresherThanMinutes = 0;
+    } else if (typeof ttlMinutes === 'number' && Number.isFinite(ttlMinutes)) {
+      skipIfFresherThanMinutes = Math.max(0, Math.floor(ttlMinutes));
+    }
+
+    const pool = await getPool();
+    const request = pool.request()
+      .input('planoMidiaGrupoPk_st', sql.NVarChar(sql.MAX), csv);
+
+    if (skipIfFresherThanMinutes !== null) {
+      request.input('skipIfFresherThanMinutes_vl', sql.Int, skipIfFresherThanMinutes);
+    }
+
+    console.log(
+      `🔄 [relatorio-p1a-refresh] pks=${csv} force=${force} ttl=${ttlMinutes ?? 'default'} → skipIfFresherThanMinutes_vl=${skipIfFresherThanMinutes ?? '(default da SP)'}`,
+    );
+
+    const result = await request.execute('[serv_product_be180].[sp_reportDataP1aEmpilhamentoRefresh]');
+
+    return res.status(200).json({ rows: result.recordset || [] });
+  } catch (err) {
+    console.error('❌ [relatorio-p1a-refresh] Erro:', err);
+    return res.status(500).json({ error: err.message || 'Erro ao atualizar stage P1A' });
+  }
+};

--- a/handlers/relatorio-p1a-utils.js
+++ b/handlers/relatorio-p1a-utils.js
@@ -1,0 +1,79 @@
+/**
+ * Utilidades compartilhadas pelos handlers do Relatório P1A.
+ *
+ * Aceita reportPks como número, string CSV ou array (mesmo padrão usado
+ * pela aplicação parceira) e devolve a string CSV exigida pelo parâmetro
+ * @planoMidiaGrupoPk_st NVARCHAR(MAX) das stored procedures.
+ */
+function normalizePks(value) {
+  if (value === undefined || value === null || value === '') return null;
+
+  let arr = [];
+  if (Array.isArray(value)) {
+    arr = value;
+  } else if (typeof value === 'number') {
+    arr = [value];
+  } else if (typeof value === 'string') {
+    arr = value.split(',');
+  } else {
+    return null;
+  }
+
+  const normalized = arr
+    .map((v) => String(v).trim())
+    .filter((v) => v.length > 0)
+    .map((v) => Number(v))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  if (normalized.length === 0) return null;
+  // Remover duplicatas mantendo ordem
+  const seen = new Set();
+  const dedup = [];
+  for (const n of normalized) {
+    if (!seen.has(n)) {
+      seen.add(n);
+      dedup.push(n);
+    }
+  }
+  return dedup.join(',');
+}
+
+/**
+ * Aceita reportPks ou reportPk (retrocompat single-pk).
+ * Retorna { csv, error } — error é mensagem amigável quando inválido.
+ */
+function extractReportPksCsv(body) {
+  const raw = body?.reportPks ?? body?.reportPk ?? null;
+  const csv = normalizePks(raw);
+  if (!csv) {
+    return {
+      csv: null,
+      error: 'reportPks é obrigatório (number, number[] ou CSV string)',
+    };
+  }
+  return { csv, error: null };
+}
+
+const VALID_DIMENSIONS = ['GEO', 'PRACA', 'UF'];
+const VALID_NEGOCIACOES = ['TOTAL', 'FATURAVEL', 'NAO_FATURAVEL'];
+
+function normalizeDimension(value, fallback = 'GEO') {
+  if (!value) return fallback;
+  const upper = String(value).toUpperCase();
+  return VALID_DIMENSIONS.includes(upper) ? upper : fallback;
+}
+
+function normalizeNegociacao(value) {
+  if (!value) return 'TOTAL';
+  const upper = String(value).toUpperCase();
+  return VALID_NEGOCIACOES.includes(upper) ? upper : 'TOTAL';
+}
+
+module.exports = {
+  normalizePks,
+  extractReportPksCsv,
+  normalizeDimension,
+  normalizeNegociacao,
+  VALID_DIMENSIONS,
+  VALID_NEGOCIACOES,
+};

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -222,7 +222,22 @@ export const Sidebar: React.FC<SidebarProps> = ({ menuReduzido, setMenuReduzido 
             )}
           </div>
         </Link>
-        
+
+        <Link to="/relatorio-p1a" className="block">
+          <div className={`flex items-center gap-2.5 group hover:bg-[#ededed] hover:text-[#222] rounded-lg px-2 py-1 transition-colors duration-200 cursor-pointer ${
+            location.pathname.startsWith("/relatorio-p1a") ? "bg-[#ededed] text-[#222]" : ""
+          }`}>
+            <svg className="w-5 h-5 text-[#757575] group-hover:text-[#222] transition-colors duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-6h13M9 5h13M3 5h2M3 11h2M3 17h2M9 11h6" />
+            </svg>
+            {!menuReduzido && (
+              <span className="font-medium text-sm text-[#757575] tracking-[0.50px] group-hover:text-[#222] transition-colors duration-200">
+                Relatório P1A
+              </span>
+            )}
+          </div>
+        </Link>
+
         {!isAgencia && (
           <Link to="/criar-roteiro" className="block">
             <div className={`flex items-center gap-2.5 group hover:bg-[#ededed] hover:text-[#222] rounded-lg px-2 py-1 transition-colors duration-200 cursor-pointer ${

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ const VisualizarResultados   = lazy(() => import("./screens/VisualizarResultados
 const BancoDeAtivos          = lazy(() => import("./screens/BancoDeAtivos").then(m => ({ default: m.BancoDeAtivos })));
 const RelatorioPorPraca      = lazy(() => import("./screens/RelatorioPorPraca").then(m => ({ default: m.RelatorioPorPraca })));
 const RelatorioPorExibidor   = lazy(() => import("./screens/RelatorioPorExibidor").then(m => ({ default: m.RelatorioPorExibidor })));
+const RelatorioP1A           = lazy(() => import("./screens/RelatorioP1A").then(m => ({ default: m.RelatorioP1A })));
 const AdminUsuarios          = lazy(() => import("./screens/Admin").then(m => ({ default: m.AdminUsuarios })));
 const AdminPerfis            = lazy(() => import("./screens/Admin").then(m => ({ default: m.AdminPerfis })));
 const PaginaEmDesenvolvimento = lazy(() => import("./components/PaginaEmDesenvolvimento").then(m => ({ default: m.PaginaEmDesenvolvimento })));
@@ -91,6 +92,9 @@ root.render(
                 } />
                 <Route path="/meus-roteiros" element={
                   <ProtectedRoute><MeusRoteiros /></ProtectedRoute>
+                } />
+                <Route path="/relatorio-p1a" element={
+                  <ProtectedRoute><RelatorioP1A /></ProtectedRoute>
                 } />
                 <Route path="/mapa" element={
                   <ProtectedRoute><Mapa /></ProtectedRoute>

--- a/src/screens/RelatorioP1A/RelatorioP1A.tsx
+++ b/src/screens/RelatorioP1A/RelatorioP1A.tsx
@@ -1,0 +1,494 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Sidebar } from '../../components/Sidebar/Sidebar';
+import { Topbar } from '../../components/Topbar/Topbar';
+import api from '../../config/axios';
+import { P1aReportSelector } from './components/P1aReportSelector';
+import { P1aFiltersBar } from './components/P1aFilters';
+import { P1aColmeiaTab } from './components/P1aColmeiaTab';
+import { P1aExibidorTab } from './components/P1aExibidorTab';
+import { P1aModeloTab } from './components/P1aModeloTab';
+import { P1aRefreshLoader } from './components/P1aLoader';
+import { exportP1aWorkbook } from './utils/exportXlsx';
+import { formatDateBr } from './utils/formatters';
+import {
+  ColmeiaRow,
+  DEFAULT_FILTERS,
+  Dimension,
+  ExibidorRow,
+  ModeloRow,
+  Negociacao,
+  OptionsResponse,
+  P1aFilters,
+  P1aTab,
+  RefreshRow,
+} from './types';
+
+function pksKey(pks: number[]): string {
+  return [...pks].sort((a, b) => a - b).join(',');
+}
+
+function parseFiltersFromUrl(sp: URLSearchParams): P1aFilters {
+  const reportPks = (sp.get('reportPks') || '')
+    .split(',')
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  const dim = (sp.get('dim') || 'GEO').toUpperCase() as Dimension;
+  const dimension: Dimension = ['GEO', 'PRACA', 'UF'].includes(dim) ? dim : 'GEO';
+  return {
+    reportPks,
+    dimension,
+    dimensionValue: sp.get('dimVal') || null,
+    marca: sp.get('marca') || null,
+    negociacao: ((sp.get('neg') || 'TOTAL').toUpperCase() as Negociacao) || 'TOTAL',
+  };
+}
+
+function buildUrl(sp: URLSearchParams, filters: P1aFilters, tab: P1aTab): URLSearchParams {
+  const next = new URLSearchParams(sp);
+  if (filters.reportPks.length > 0) {
+    next.set('reportPks', filters.reportPks.join(','));
+  } else {
+    next.delete('reportPks');
+  }
+  next.set('dim', filters.dimension);
+  if (filters.dimensionValue) next.set('dimVal', filters.dimensionValue);
+  else next.delete('dimVal');
+  if (filters.marca) next.set('marca', filters.marca);
+  else next.delete('marca');
+  next.set('neg', filters.negociacao);
+  next.set('tab', tab);
+  return next;
+}
+
+export const RelatorioP1A: React.FC = () => {
+  const [menuReduzido, setMenuReduzido] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [filters, setFilters] = useState<P1aFilters>(() => ({
+    ...DEFAULT_FILTERS,
+    ...parseFiltersFromUrl(searchParams),
+  }));
+  const [tab, setTab] = useState<P1aTab>(
+    (searchParams.get('tab') as P1aTab) || 'colmeia',
+  );
+
+  const [optionsGlobal, setOptionsGlobal] = useState<OptionsResponse | null>(null);
+  const [optionsScoped, setOptionsScoped] = useState<OptionsResponse | null>(null);
+  const [loadingOptions, setLoadingOptions] = useState(false);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshRows, setRefreshRows] = useState<RefreshRow[]>([]);
+
+  const [colmeiaRows, setColmeiaRows] = useState<ColmeiaRow[]>([]);
+  const [exibidorRows, setExibidorRows] = useState<ExibidorRow[]>([]);
+  const [modeloRows, setModeloRows] = useState<ModeloRow[]>([]);
+
+  const [loadingColmeia, setLoadingColmeia] = useState(false);
+  const [loadingExibidor, setLoadingExibidor] = useState(false);
+  const [loadingModelo, setLoadingModelo] = useState(false);
+
+  const [erro, setErro] = useState<string | null>(null);
+  const [exportando, setExportando] = useState(false);
+
+  const selectedKey = pksKey(filters.reportPks);
+
+  // Manter URL em sincronia com filtros + tab
+  useEffect(() => {
+    setSearchParams(buildUrl(searchParams, filters, tab), { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedKey, filters.dimension, filters.dimensionValue, filters.marca, filters.negociacao, tab]);
+
+  // Carregar lista global de roteiros
+  useEffect(() => {
+    let cancelado = false;
+    (async () => {
+      try {
+        setLoadingOptions(true);
+        setErro(null);
+        const resp = await api.get('/relatorio-p1a-options');
+        if (!cancelado) setOptionsGlobal(resp.data);
+      } catch (err: any) {
+        if (!cancelado) setErro(err?.response?.data?.error || 'Erro ao carregar roteiros');
+      } finally {
+        if (!cancelado) setLoadingOptions(false);
+      }
+    })();
+    return () => {
+      cancelado = true;
+    };
+  }, []);
+
+  // Refresh do stage e carga das opções escopadas + dados das abas
+  useEffect(() => {
+    if (filters.reportPks.length === 0) {
+      setOptionsScoped(null);
+      setColmeiaRows([]);
+      setExibidorRows([]);
+      setModeloRows([]);
+      setRefreshRows([]);
+      return;
+    }
+
+    let cancelado = false;
+    (async () => {
+      try {
+        setRefreshing(true);
+        setErro(null);
+        const respRefresh = await api.post('/relatorio-p1a-refresh', {
+          reportPks: filters.reportPks,
+        });
+        if (!cancelado) setRefreshRows(respRefresh.data?.rows || []);
+
+        // Após refresh, busca opções escopadas (marcas, GEOs, etc.)
+        const respOpts = await api.get(
+          `/relatorio-p1a-options?reportPks=${filters.reportPks.join(',')}`,
+        );
+        if (!cancelado) setOptionsScoped(respOpts.data);
+      } catch (err: any) {
+        if (!cancelado) setErro(err?.response?.data?.error || 'Erro ao atualizar dados P1A');
+      } finally {
+        if (!cancelado) setRefreshing(false);
+      }
+    })();
+
+    return () => {
+      cancelado = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedKey]);
+
+  // Carga das 3 abas após refresh / mudança de filtros
+  const fetchColmeia = useCallback(async () => {
+    if (filters.reportPks.length === 0 || refreshing) return;
+    try {
+      setLoadingColmeia(true);
+      const resp = await api.post('/relatorio-p1a-colmeia', {
+        reportPks: filters.reportPks,
+        dimension: filters.dimension,
+        dimensionValue: filters.dimensionValue,
+      });
+      setColmeiaRows(resp.data?.rows || []);
+    } catch (err: any) {
+      setErro(err?.response?.data?.error || 'Erro ao carregar aba Colmeia');
+    } finally {
+      setLoadingColmeia(false);
+    }
+  }, [filters.reportPks, filters.dimension, filters.dimensionValue, refreshing]);
+
+  const fetchExibidor = useCallback(async () => {
+    if (filters.reportPks.length === 0 || refreshing) return;
+    try {
+      setLoadingExibidor(true);
+      const resp = await api.post('/relatorio-p1a-exibidor', {
+        reportPks: filters.reportPks,
+        dimension: filters.dimension,
+        dimensionValue: filters.dimensionValue,
+        marca: filters.marca,
+        negociacao: filters.negociacao,
+      });
+      setExibidorRows(resp.data?.rows || []);
+    } catch (err: any) {
+      setErro(err?.response?.data?.error || 'Erro ao carregar aba Exibidor');
+    } finally {
+      setLoadingExibidor(false);
+    }
+  }, [
+    filters.reportPks,
+    filters.dimension,
+    filters.dimensionValue,
+    filters.marca,
+    filters.negociacao,
+    refreshing,
+  ]);
+
+  const fetchModelo = useCallback(async () => {
+    if (filters.reportPks.length === 0 || refreshing) return;
+    try {
+      setLoadingModelo(true);
+      const resp = await api.post('/relatorio-p1a-modelo', {
+        reportPks: filters.reportPks,
+        dimension: filters.dimension,
+        dimensionValue: filters.dimensionValue,
+        marca: filters.marca,
+        negociacao: filters.negociacao,
+      });
+      setModeloRows(resp.data?.rows || []);
+    } catch (err: any) {
+      setErro(err?.response?.data?.error || 'Erro ao carregar aba Modelo P1A');
+    } finally {
+      setLoadingModelo(false);
+    }
+  }, [
+    filters.reportPks,
+    filters.dimension,
+    filters.dimensionValue,
+    filters.marca,
+    filters.negociacao,
+    refreshing,
+  ]);
+
+  useEffect(() => {
+    fetchColmeia();
+  }, [fetchColmeia]);
+
+  useEffect(() => {
+    fetchExibidor();
+  }, [fetchExibidor]);
+
+  useEffect(() => {
+    fetchModelo();
+  }, [fetchModelo]);
+
+  const handleRefreshForcado = useCallback(async () => {
+    if (filters.reportPks.length === 0) return;
+    try {
+      setRefreshing(true);
+      setErro(null);
+      const resp = await api.post('/relatorio-p1a-refresh', {
+        reportPks: filters.reportPks,
+        force: true,
+      });
+      setRefreshRows(resp.data?.rows || []);
+      // Recarrega as 3 abas
+      await Promise.all([fetchColmeia(), fetchExibidor(), fetchModelo()]);
+    } catch (err: any) {
+      setErro(err?.response?.data?.error || 'Erro ao forçar atualização');
+    } finally {
+      setRefreshing(false);
+    }
+  }, [filters.reportPks, fetchColmeia, fetchExibidor, fetchModelo]);
+
+  const handleExport = useCallback(async () => {
+    if (filters.reportPks.length === 0) return;
+    try {
+      setExportando(true);
+      exportP1aWorkbook({
+        dimension: filters.dimension,
+        dimensionValue: filters.dimensionValue,
+        colmeiaRows,
+        exibidorRows,
+        modeloRows,
+      });
+    } finally {
+      setExportando(false);
+    }
+  }, [
+    filters.reportPks,
+    filters.dimension,
+    filters.dimensionValue,
+    colmeiaRows,
+    exibidorRows,
+    modeloRows,
+  ]);
+
+  const optionsParaUI = useMemo<OptionsResponse | null>(() => {
+    if (optionsScoped) {
+      return {
+        ...optionsScoped,
+        reports: optionsGlobal?.reports || optionsScoped.reports || [],
+      };
+    }
+    return optionsGlobal;
+  }, [optionsGlobal, optionsScoped]);
+
+  const lastRefreshedAt = useMemo(() => {
+    if (refreshRows.length === 0) return null;
+    const ts = refreshRows
+      .map((r) => (r.refreshedAt_dh ? new Date(r.refreshedAt_dh).getTime() : 0))
+      .filter((t) => t > 0);
+    if (ts.length === 0) return null;
+    return new Date(Math.max(...ts)).toISOString();
+  }, [refreshRows]);
+
+  const hasSimulatedPlans = refreshRows.some((r) => r.sourceType_st === 'colmeia');
+  const stageRowsWritten = refreshRows.reduce(
+    (acc, r) => acc + (Number(r.rowsWritten_vl) || 0),
+    0,
+  );
+
+  return (
+    <div className="min-h-screen bg-white flex font-sans">
+      <Sidebar menuReduzido={menuReduzido} setMenuReduzido={setMenuReduzido} />
+      <div
+        className={`fixed top-0 z-20 h-screen w-px bg-[#c1c1c1] ${
+          menuReduzido ? 'left-20' : 'left-64'
+        }`}
+      />
+      <div
+        className={`flex-1 transition-all duration-300 min-h-screen w-full ${
+          menuReduzido ? 'ml-20' : 'ml-64'
+        } flex flex-col`}
+      >
+        <Topbar
+          menuReduzido={menuReduzido}
+          breadcrumb={{
+            items: [
+              { label: 'Home', path: '/' },
+              { label: 'Relatório P1A' },
+            ],
+          }}
+        />
+        <div
+          className={`fixed top-[72px] z-30 h-[1px] bg-[#c1c1c1] ${
+            menuReduzido ? 'left-20 w-[calc(100%-5rem)]' : 'left-64 w-[calc(100%-16rem)]'
+          }`}
+        />
+
+        <div className="flex-1 pt-24 pb-32 px-8 overflow-auto">
+          <div className="max-w-[1400px] mx-auto">
+            {/* Cabeçalho */}
+            <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-6">
+              <div>
+                <h1 className="text-3xl font-bold text-[#ff4600] uppercase tracking-wide">
+                  Relatório P1A
+                </h1>
+                <p className="text-[#3a3a3a] mt-2 max-w-3xl">
+                  Visualize o resultado consolidado de um ou mais roteiros nas três visões do
+                  modelo P1A: Colmeia, Exibidor e Modelo P1A. Selecione os roteiros e ajuste
+                  os filtros para comparar GEO, praça ou UF.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleRefreshForcado}
+                  disabled={filters.reportPks.length === 0 || refreshing}
+                  className="px-3 py-2 text-sm rounded-md border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a] disabled:opacity-50"
+                >
+                  {refreshing ? 'Atualizando…' : 'Atualizar'}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleExport}
+                  disabled={
+                    filters.reportPks.length === 0 ||
+                    exportando ||
+                    refreshing ||
+                    (colmeiaRows.length === 0 &&
+                      exibidorRows.length === 0 &&
+                      modeloRows.length === 0)
+                  }
+                  className="px-3 py-2 text-sm rounded-md bg-[#ff4600] text-white hover:bg-[#e63d00] disabled:opacity-50"
+                >
+                  {exportando ? 'Exportando…' : 'Exportar .xlsx'}
+                </button>
+              </div>
+            </div>
+
+            {/* Seletor de roteiros */}
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-[#757575] uppercase tracking-wide mb-1">
+                Roteiros
+              </label>
+              <P1aReportSelector
+                reports={optionsGlobal?.reports || []}
+                selected={filters.reportPks}
+                onChange={(next) => setFilters((f) => ({ ...f, reportPks: next }))}
+                loading={loadingOptions}
+              />
+            </div>
+
+            {/* Filtros */}
+            <div className="mb-4">
+              <P1aFiltersBar
+                filters={filters}
+                options={optionsParaUI}
+                onChange={setFilters}
+                disabled={refreshing || filters.reportPks.length === 0}
+              />
+            </div>
+
+            {/* Loader do refresh — ocupa o espaço das abas enquanto o stage é reconstruído */}
+            {refreshing && filters.reportPks.length > 0 && (
+              <div className="py-8">
+                <P1aRefreshLoader reportCount={filters.reportPks.length} />
+              </div>
+            )}
+
+            {/* Meta do último refresh (quando concluído) */}
+            {!refreshing && filters.reportPks.length > 0 && (
+              <div className="flex flex-wrap items-center gap-3 text-xs text-[#757575] mb-4">
+                {lastRefreshedAt && (
+                  <span>
+                    Stage atualizado em{' '}
+                    <strong className="text-[#3a3a3a]">{formatDateBr(lastRefreshedAt)}</strong>
+                  </span>
+                )}
+                {stageRowsWritten > 0 && (
+                  <span className="flex items-center gap-1">
+                    <svg className="w-3 h-3 text-[#ff4600]" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                    </svg>
+                    {stageRowsWritten.toLocaleString('pt-BR')} linhas
+                  </span>
+                )}
+                {hasSimulatedPlans && (
+                  <span className="px-2 py-0.5 rounded-full bg-[#fff8e1] text-[#8a6d00] border border-[#ffd87a]">
+                    Contém roteiros simulados
+                  </span>
+                )}
+              </div>
+            )}
+
+            {erro && (
+              <div className="mb-4 px-4 py-3 rounded-lg border border-red-200 bg-red-50 text-sm text-red-700">
+                {erro}
+              </div>
+            )}
+
+            {/* Abas + conteúdo — só aparecem quando o refresh está concluído */}
+            {!refreshing && (
+              <>
+                <div className="border-b border-[#ededed] flex items-center gap-1 mb-4">
+                  {(
+                    [
+                      { id: 'colmeia', label: 'Colmeia' },
+                      { id: 'exibidor', label: 'Exibidor' },
+                      { id: 'modelo', label: 'Modelo P1A' },
+                    ] as Array<{ id: P1aTab; label: string }>
+                  ).map((t) => (
+                    <button
+                      key={t.id}
+                      type="button"
+                      onClick={() => setTab(t.id)}
+                      className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                        tab === t.id
+                          ? 'text-[#ff4600] border-[#ff4600]'
+                          : 'text-[#757575] border-transparent hover:text-[#3a3a3a]'
+                      }`}
+                    >
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
+
+                {tab === 'colmeia' && (
+                  <P1aColmeiaTab
+                    rows={colmeiaRows}
+                    dimension={filters.dimension}
+                    loading={loadingColmeia}
+                  />
+                )}
+                {tab === 'exibidor' && (
+                  <P1aExibidorTab
+                    rows={exibidorRows}
+                    loading={loadingExibidor}
+                    hasSimulatedPlans={hasSimulatedPlans}
+                  />
+                )}
+                {tab === 'modelo' && (
+                  <P1aModeloTab
+                    rows={modeloRows}
+                    loading={loadingModelo}
+                    hasSimulatedPlans={hasSimulatedPlans}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/RelatorioP1A/components/P1aColmeiaTab.tsx
+++ b/src/screens/RelatorioP1A/components/P1aColmeiaTab.tsx
@@ -1,0 +1,141 @@
+import React, { useMemo } from 'react';
+import { ColmeiaRow, Dimension } from '../types';
+import { fmt2, fmt4, fmtInt, fmtPct, toNum } from '../utils/formatters';
+import { P1aTableSkeleton } from './P1aLoader';
+
+interface P1aColmeiaTabProps {
+  rows: ColmeiaRow[];
+  dimension: Dimension;
+  loading?: boolean;
+}
+
+interface MetricaConfig {
+  label: string;
+  field: keyof ColmeiaRow;
+  format: (value: unknown) => string;
+}
+
+/**
+ * Métricas da aba 5 do workbook P1A. Os nomes refletem exatamente os
+ * campos retornados por `sp_reportResultColmeiaGeoClosed`.
+ */
+const METRICAS: MetricaConfig[] = [
+  { label: 'Impactos Vias públicas', field: 'impactosIpv_vl', format: fmtInt },
+  { label: 'Cobertura Vias públicas', field: 'coberturaPessoas_vl', format: fmtInt },
+  { label: 'Cobertura (%)', field: 'coberturaProp_vl', format: fmtPct },
+  { label: 'Frequência teórica', field: 'frequenciaTeorica_vl', format: fmt2 },
+  { label: 'Frequência', field: 'frequencia_vl', format: fmt2 },
+  { label: 'GRP', field: 'grp_vl', format: fmt2 },
+  { label: 'Deflator do inventário', field: 'deflatorInventario_vl', format: fmt4 },
+  { label: '% Dominação', field: 'dominacao_vl', format: fmtPct },
+  { label: 'Pontos Praça', field: 'pontosPraca_vl', format: fmtInt },
+  { label: 'Pontos', field: 'pontos_vl', format: fmtInt },
+  { label: 'População', field: 'populationTotal_vl', format: fmtInt },
+];
+
+function dimensionKey(row: ColmeiaRow): string {
+  return (
+    (row.dimensionValue_st as string) ||
+    (row.geoAmbev_st as string) ||
+    '—'
+  );
+}
+
+export const P1aColmeiaTab: React.FC<P1aColmeiaTabProps> = ({ rows, dimension, loading }) => {
+  const blocos = useMemo(() => {
+    const groups = new Map<
+      string,
+      { semanas: Set<number>; rowsByWeek: Map<number, ColmeiaRow>; segmento: string | null }
+    >();
+
+    rows.forEach((row) => {
+      const dimVal = dimensionKey(row);
+      const week = toNum(row.week_vl);
+      if (week === null) return;
+      let group = groups.get(dimVal);
+      if (!group) {
+        group = { semanas: new Set(), rowsByWeek: new Map(), segmento: null };
+        groups.set(dimVal, group);
+      }
+      group.semanas.add(week);
+      group.rowsByWeek.set(week, row);
+      if (!group.segmento && row.segmento_st) group.segmento = row.segmento_st;
+    });
+
+    return Array.from(groups.entries())
+      .sort((a, b) => a[0].localeCompare(b[0], 'pt-BR'))
+      .map(([dimVal, group]) => ({
+        dimVal,
+        segmento: group.segmento,
+        semanas: Array.from(group.semanas).sort((a, b) => a - b),
+        rowsByWeek: group.rowsByWeek,
+      }));
+  }, [rows]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <P1aTableSkeleton rows={11} cols={4} />
+      </div>
+    );
+  }
+
+  if (blocos.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-[#ededed] p-12 text-center text-[#757575]">
+        Selecione um ou mais roteiros para visualizar os dados Colmeia.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {blocos.map(({ dimVal, segmento, semanas, rowsByWeek }) => (
+        <div key={dimVal} className="bg-white rounded-lg border border-[#ededed] overflow-hidden">
+          <div className="bg-[#fff5ef] border-b border-[#ffd9c4] px-4 py-2 flex items-center gap-2 flex-wrap">
+            <span className="text-xs uppercase tracking-wide text-[#ff4600] font-bold">
+              {dimension}
+            </span>
+            <span className="text-sm font-semibold text-[#3a3a3a]">{dimVal}</span>
+            {segmento && (
+              <span className="ml-auto text-xs text-[#8a6d00] bg-[#fff8e1] border border-[#ffd87a] rounded-full px-2 py-0.5">
+                Segmento: {segmento}
+              </span>
+            )}
+          </div>
+          <div className="overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="bg-[#f8f8f8] text-left text-xs uppercase tracking-wide text-[#757575]">
+                  <th className="px-3 py-2 sticky left-0 bg-[#f8f8f8] min-w-[220px]">Métrica</th>
+                  {semanas.map((s) => (
+                    <th key={s} className="px-3 py-2 text-right whitespace-nowrap">
+                      W{s}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {METRICAS.map((m) => (
+                  <tr key={m.label} className="border-t border-[#f0f0f0]">
+                    <td className="px-3 py-2 font-medium text-[#3a3a3a] sticky left-0 bg-white">
+                      {m.label}
+                    </td>
+                    {semanas.map((s) => {
+                      const row = rowsByWeek.get(s);
+                      return (
+                        <td key={s} className="px-3 py-2 text-right font-mono text-xs">
+                          {row ? m.format(row[m.field]) : '—'}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/screens/RelatorioP1A/components/P1aExibidorTab.tsx
+++ b/src/screens/RelatorioP1A/components/P1aExibidorTab.tsx
@@ -1,0 +1,233 @@
+import React, { useMemo } from 'react';
+import { ExibidorRow } from '../types';
+import { nomeExibidor, ordenarExibidores } from '../utils/exibidores';
+import { fmt2, fmtBRL, fmtInt, fmtPct, toNum } from '../utils/formatters';
+import { P1aTableSkeleton } from './P1aLoader';
+
+interface P1aExibidorTabProps {
+  rows: ExibidorRow[];
+  loading?: boolean;
+  hasSimulatedPlans?: boolean;
+}
+
+interface MetricaExibidor {
+  label: string;
+  field: keyof ExibidorRow;
+  format: (value: unknown) => string;
+}
+
+/**
+ * Métricas por exibidor — mapeadas para os campos reais retornados por
+ * `sp_reportResultExibidor{Geo,Praca,Uf}Closed`.
+ */
+const METRICAS_EXIBIDOR: MetricaExibidor[] = [
+  { label: '% Faces', field: 'pctFaces_vl', format: fmtPct },
+  { label: 'Impactos', field: 'impactosTotal_vl', format: fmtInt },
+  { label: 'Investimento', field: 'investimento_vl', format: fmtBRL },
+  { label: 'Cobertura (%)', field: 'coberturaProp_vl', format: fmtPct },
+  { label: 'Cobertura (pessoas)', field: 'coberturaPessoas_vl', format: fmtInt },
+  { label: 'Frequência', field: 'frequencia_vl', format: fmt2 },
+  { label: 'Faces (total)', field: 'facesTotal_vl', format: fmtInt },
+  { label: 'Faces vias públicas', field: 'facesViasPublicas_vl', format: fmtInt },
+  { label: 'Faces FATURÁVEIS', field: 'facesFaturaveis_vl', format: fmtInt },
+  { label: 'Faces NÃO faturáveis', field: 'facesNaoFaturaveis_vl', format: fmtInt },
+  { label: 'Localidades indoor', field: 'localidadesIndoor_vl', format: fmtInt },
+  { label: 'Localidades indoor FAT', field: 'localidadesIndoorFaturaveis_vl', format: fmtInt },
+  { label: 'Localidades indoor NÃO-FAT', field: 'localidadesIndoorNaoFaturaveis_vl', format: fmtInt },
+  { label: 'Impressões qualificadas', field: 'impressoesQualificadas_vl', format: fmtInt },
+];
+
+interface MetricaTotal {
+  label: string;
+  pick: (row: ExibidorRow) => unknown;
+  format: (value: unknown) => string;
+}
+
+/**
+ * Bloco TOTAL (campos `*Sheet_vl` agregados pela SP). Repete em toda
+ * linha, então pega-se uma linha qualquer por (dimVal × week).
+ */
+const METRICAS_TOTAL: MetricaTotal[] = [
+  { label: 'Impactos (TOTAL)', pick: (r) => r.impactosTotalSheet_vl, format: fmtInt },
+  {
+    label: 'Cobertura (proporcional × população)',
+    pick: (r) => {
+      const cob = toNum(r.coberturaPropTotalSheet_vl) ?? 0;
+      const pop = toNum(r.populationTotalSheet_vl) ?? 0;
+      return cob * pop;
+    },
+    format: fmtInt,
+  },
+  { label: 'Cobertura proporcional (%)', pick: (r) => r.coberturaPropTotalSheet_vl, format: fmtPct },
+  { label: 'População', pick: (r) => r.populationTotalSheet_vl, format: fmtInt },
+  { label: 'Faces totais', pick: (r) => r.facesTotalSheet_vl, format: fmtInt },
+  { label: 'Localidades indoor', pick: (r) => r.localidadesIndoorTotalSheet_vl, format: fmtInt },
+  { label: 'Pontos Praça', pick: (r) => r.pontosPracaSheet_vl, format: fmtInt },
+  { label: 'Pontos', pick: (r) => r.pontosSheet_vl, format: fmtInt },
+];
+
+export const P1aExibidorTab: React.FC<P1aExibidorTabProps> = ({
+  rows,
+  loading,
+  hasSimulatedPlans,
+}) => {
+  const blocos = useMemo(() => {
+    const byDim = new Map<string, ExibidorRow[]>();
+    rows.forEach((row) => {
+      const k = (row.dimensionValue_st as string) || '—';
+      const arr = byDim.get(k) || [];
+      arr.push(row);
+      byDim.set(k, arr);
+    });
+
+    return Array.from(byDim.entries())
+      .sort((a, b) => a[0].localeCompare(b[0], 'pt-BR'))
+      .map(([dimVal, dimRows]) => {
+        const semanas = Array.from(
+          new Set(
+            dimRows
+              .map((r) => toNum(r.week_vl))
+              .filter((v): v is number => v !== null),
+          ),
+        ).sort((a, b) => a - b);
+        const exibidores = ordenarExibidores(dimRows.map((r) => r.exibidorP1a_st));
+
+        const idxByExibidor = new Map<string, Map<number, ExibidorRow>>();
+        dimRows.forEach((row) => {
+          const ex = nomeExibidor(row.exibidorP1a_st);
+          const w = toNum(row.week_vl);
+          if (w === null) return;
+          let m = idxByExibidor.get(ex);
+          if (!m) {
+            m = new Map();
+            idxByExibidor.set(ex, m);
+          }
+          m.set(w, row);
+        });
+
+        const totalRowBySemana = new Map<number, ExibidorRow>();
+        dimRows.forEach((r) => {
+          const s = toNum(r.week_vl);
+          if (s === null) return;
+          if (!totalRowBySemana.has(s)) totalRowBySemana.set(s, r);
+        });
+
+        return { dimVal, semanas, exibidores, idxByExibidor, totalRowBySemana };
+      });
+  }, [rows]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <P1aTableSkeleton rows={8} cols={4} />
+        <P1aTableSkeleton rows={14} cols={4} />
+      </div>
+    );
+  }
+
+  if (blocos.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-[#ededed] p-12 text-center text-[#757575]">
+        Selecione um ou mais roteiros para visualizar os dados de Exibidor.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {hasSimulatedPlans && (
+        <div className="rounded-lg border border-[#ffd87a] bg-[#fff8e1] px-4 py-3 text-sm text-[#8a6d00]">
+          <strong>Atenção:</strong> a seleção contém roteiros simulados (origem Colmeia).
+          Métricas de investimento, faces faturáveis/não faturáveis e localidades indoor
+          faturáveis/não faturáveis podem vir zeradas — apenas métricas físicas
+          (faces, impactos, cobertura) são válidas para esses casos.
+        </div>
+      )}
+
+      {blocos.map(({ dimVal, semanas, exibidores, idxByExibidor, totalRowBySemana }) => (
+        <div key={dimVal} className="bg-white rounded-lg border border-[#ededed] overflow-hidden">
+          <div className="bg-[#fff5ef] border-b border-[#ffd9c4] px-4 py-2">
+            <span className="text-sm font-semibold text-[#3a3a3a]">{dimVal}</span>
+          </div>
+
+          <div className="overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="bg-[#f8f8f8] text-left text-xs uppercase tracking-wide text-[#757575]">
+                  <th className="px-3 py-2 sticky left-0 bg-[#f8f8f8] min-w-[280px]">Métrica</th>
+                  {semanas.map((s) => (
+                    <th key={s} className="px-3 py-2 text-right whitespace-nowrap">
+                      W{s}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    colSpan={semanas.length + 1}
+                    className="px-3 py-1.5 bg-[#fff8e1] text-xs uppercase tracking-wide text-[#8a6d00] font-bold"
+                  >
+                    TOTAL
+                  </td>
+                </tr>
+                {METRICAS_TOTAL.map((m) => (
+                  <tr key={m.label} className="border-t border-[#f0f0f0] bg-[#fffdf5]">
+                    <td className="px-3 py-2 font-medium text-[#3a3a3a] sticky left-0 bg-[#fffdf5]">
+                      {m.label}
+                    </td>
+                    {semanas.map((s) => {
+                      const row = totalRowBySemana.get(s);
+                      return (
+                        <td key={s} className="px-3 py-2 text-right font-mono text-xs">
+                          {row ? m.format(m.pick(row)) : '—'}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+
+                {exibidores.map((exibidor) => (
+                  <React.Fragment key={exibidor}>
+                    <tr>
+                      <td
+                        colSpan={semanas.length + 1}
+                        className={`px-3 py-1.5 text-xs uppercase tracking-wide font-bold ${
+                          exibidor.toLowerCase() === 'demais ooh'
+                            ? 'bg-[#ededed] text-[#3a3a3a]'
+                            : exibidor.toLowerCase() === 'não informado'
+                            ? 'bg-[#fff8e1] text-[#8a6d00]'
+                            : 'bg-[#f8f8f8] text-[#3a3a3a]'
+                        }`}
+                      >
+                        {exibidor}
+                      </td>
+                    </tr>
+                    {METRICAS_EXIBIDOR.map((m) => {
+                      const semanaMap = idxByExibidor.get(exibidor);
+                      return (
+                        <tr key={`${exibidor}-${m.label}`} className="border-t border-[#f0f0f0]">
+                          <td className="px-3 py-2 text-[#3a3a3a] sticky left-0 bg-white">
+                            {m.label}
+                          </td>
+                          {semanas.map((s) => {
+                            const row = semanaMap?.get(s);
+                            return (
+                              <td key={s} className="px-3 py-2 text-right font-mono text-xs">
+                                {row ? m.format(row[m.field]) : '—'}
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      );
+                    })}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/screens/RelatorioP1A/components/P1aFilters.tsx
+++ b/src/screens/RelatorioP1A/components/P1aFilters.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Dimension, Negociacao, OptionsResponse, P1aFilters } from '../types';
+
+interface P1aFiltersProps {
+  filters: P1aFilters;
+  options: OptionsResponse | null;
+  onChange: (next: P1aFilters) => void;
+  disabled?: boolean;
+}
+
+const DIMENSION_LABEL: Record<Dimension, string> = {
+  GEO: 'GEO',
+  PRACA: 'Praça',
+  UF: 'UF',
+};
+
+const NEGOCIACAO_LABEL: Record<Negociacao, string> = {
+  TOTAL: 'Total',
+  FATURAVEL: 'Faturável',
+  NAO_FATURAVEL: 'Não faturável',
+};
+
+export const P1aFiltersBar: React.FC<P1aFiltersProps> = ({
+  filters,
+  options,
+  onChange,
+  disabled,
+}) => {
+  const dimensionValues = options?.dimensions[filters.dimension] ?? [];
+  const marcas = options?.marcas ?? [];
+
+  const update = (patch: Partial<P1aFilters>) => onChange({ ...filters, ...patch });
+
+  const baseSelectClass =
+    'h-[44px] px-3 rounded-lg border bg-white text-sm text-[#3a3a3a] focus:outline-none focus:ring-2 focus:ring-[#ff4600]/30 focus:border-[#ff4600] disabled:bg-[#f8f8f8] disabled:text-[#999]';
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-[#757575] uppercase tracking-wide">
+          Marca
+        </label>
+        <select
+          className={`${baseSelectClass} border-[#d9d9d9]`}
+          value={filters.marca ?? ''}
+          onChange={(e) => update({ marca: e.target.value || null })}
+          disabled={disabled || marcas.length === 0}
+        >
+          <option value="">Todas</option>
+          {marcas.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-[#757575] uppercase tracking-wide">
+          Dimensão
+        </label>
+        <select
+          className={`${baseSelectClass} border-[#d9d9d9]`}
+          value={filters.dimension}
+          onChange={(e) =>
+            update({ dimension: e.target.value as Dimension, dimensionValue: null })
+          }
+          disabled={disabled}
+        >
+          {(['GEO', 'PRACA', 'UF'] as Dimension[]).map((d) => (
+            <option key={d} value={d}>
+              {DIMENSION_LABEL[d]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-[#757575] uppercase tracking-wide">
+          Valor da dimensão
+        </label>
+        <select
+          className={`${baseSelectClass} border-[#d9d9d9]`}
+          value={filters.dimensionValue ?? ''}
+          onChange={(e) => update({ dimensionValue: e.target.value || null })}
+          disabled={disabled || dimensionValues.length === 0}
+        >
+          <option value="">Todas</option>
+          {dimensionValues.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-[#757575] uppercase tracking-wide">
+          Negociação
+        </label>
+        <select
+          className={`${baseSelectClass} border-[#d9d9d9]`}
+          value={filters.negociacao}
+          onChange={(e) => update({ negociacao: e.target.value as Negociacao })}
+          disabled={disabled}
+        >
+          {(['TOTAL', 'FATURAVEL', 'NAO_FATURAVEL'] as Negociacao[]).map((n) => (
+            <option key={n} value={n}>
+              {NEGOCIACAO_LABEL[n]}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/RelatorioP1A/components/P1aLoader.tsx
+++ b/src/screens/RelatorioP1A/components/P1aLoader.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useState } from 'react';
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   P1aRefreshLoader
+   Exibido enquanto o stage está sendo reconstruído (sp_reportDataP1aEmpilhamentoRefresh).
+   Mostra passos animados com progresso temporal — sem barra falsa de % pois
+   o tempo real varia; usamos etapas com shimmer no ícone.
+   ───────────────────────────────────────────────────────────────────────────── */
+
+const ETAPAS = [
+  { label: 'Recebendo roteiros selecionados', durationMs: 600 },
+  { label: 'Apagando dados anteriores do stage', durationMs: 1200 },
+  { label: 'Recalculando empilhamento de semanas', durationMs: 1800 },
+  { label: 'Gravando resultados consolidados', durationMs: 1200 },
+  { label: 'Finalizando e verificando integridade', durationMs: 0 },
+];
+
+interface P1aRefreshLoaderProps {
+  reportCount?: number;
+}
+
+export const P1aRefreshLoader: React.FC<P1aRefreshLoaderProps> = ({ reportCount = 1 }) => {
+  const [etapa, setEtapa] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    if (etapa >= ETAPAS.length - 1) return;
+    const d = ETAPAS[etapa].durationMs;
+    if (d === 0) return;
+    const t = setTimeout(() => setEtapa((e) => e + 1), d);
+    return () => clearTimeout(t);
+  }, [etapa]);
+
+  const m = Math.floor(elapsed / 60);
+  const s = elapsed % 60;
+  const tempoStr = m > 0 ? `${m}min ${s}s` : `${s}s`;
+
+  return (
+    <div className="bg-white rounded-xl border border-[#ededed] px-8 py-10 flex flex-col items-center gap-6 max-w-xl mx-auto shadow-sm">
+      {/* Spinner laranja */}
+      <div className="relative">
+        <div className="w-14 h-14 rounded-full border-[3px] border-[#f0f0f0] border-t-[#ff4600] animate-spin" />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <svg className="w-5 h-5 text-[#ff4600]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7M4 7h16M4 7l2-3h12l2 3" />
+          </svg>
+        </div>
+      </div>
+
+      <div className="text-center">
+        <h3 className="text-base font-semibold text-[#222]">Sincronizando dados P1A</h3>
+        <p className="text-sm text-[#757575] mt-1">
+          {reportCount === 1
+            ? 'Atualizando 1 roteiro no stage'
+            : `Atualizando ${reportCount} roteiros no stage`}
+        </p>
+      </div>
+
+      <ul className="w-full space-y-2">
+        {ETAPAS.map((e, i) => {
+          const done = i < etapa;
+          const active = i === etapa;
+          const pending = i > etapa;
+          return (
+            <li key={e.label} className="flex items-center gap-3">
+              <div
+                className={`w-5 h-5 rounded-full flex-shrink-0 flex items-center justify-center transition-colors duration-300 ${
+                  done
+                    ? 'bg-[#ff4600] text-white'
+                    : active
+                    ? 'border-2 border-[#ff4600] bg-white'
+                    : 'border-2 border-[#e0e0e0] bg-white'
+                }`}
+              >
+                {done ? (
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : active ? (
+                  <div className="w-2 h-2 rounded-full bg-[#ff4600] animate-pulse" />
+                ) : null}
+              </div>
+              <span
+                className={`text-sm transition-colors duration-300 ${
+                  done
+                    ? 'text-[#3a3a3a] line-through decoration-[#ccc]'
+                    : active
+                    ? 'text-[#222] font-medium'
+                    : 'text-[#bbb]'
+                }`}
+              >
+                {e.label}
+              </span>
+              {active && (
+                <span className="ml-auto text-xs text-[#ff4600] animate-pulse">em andamento</span>
+              )}
+              {pending && <span className="ml-auto text-xs text-[#d0d0d0]">aguardando</span>}
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="text-xs text-[#b3b3b3] flex items-center gap-1.5">
+        <div className="w-1.5 h-1.5 rounded-full bg-[#ff4600] animate-pulse" />
+        {tempoStr}
+      </div>
+    </div>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   P1aTableSkeleton
+   Exibido enquanto uma aba está carregando (operação rápida, ~300-600ms).
+   Imita a estrutura visual real da tabela: header laranja + linhas de métricas.
+   ───────────────────────────────────────────────────────────────────────────── */
+
+interface P1aTableSkeletonProps {
+  rows?: number;
+  cols?: number;
+}
+
+const Shimmer: React.FC<{ className?: string }> = ({ className = '' }) => (
+  <div className={`relative overflow-hidden rounded bg-[#f0f0f0] ${className}`}>
+    <div
+      className="absolute inset-0 -translate-x-full"
+      style={{
+        animation: 'p1a-shimmer 1.4s infinite',
+        background: 'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.7) 50%, transparent 100%)',
+      }}
+    />
+  </div>
+);
+
+export const P1aTableSkeleton: React.FC<P1aTableSkeletonProps> = ({
+  rows = 9,
+  cols = 4,
+}) => (
+  <>
+    <style>{`
+      @keyframes p1a-shimmer {
+        from { transform: translateX(-100%); }
+        to   { transform: translateX(200%); }
+      }
+    `}</style>
+    <div className="bg-white rounded-lg border border-[#ededed] overflow-hidden">
+      {/* Header da dimensão */}
+      <div className="bg-[#fff5ef] border-b border-[#ffd9c4] px-4 py-2 flex items-center gap-2">
+        <Shimmer className="h-4 w-10" />
+        <Shimmer className="h-4 w-36" />
+      </div>
+
+      <table className="min-w-full">
+        <thead>
+          <tr className="bg-[#f8f8f8]">
+            {/* coluna de métrica */}
+            <th className="px-3 py-2 min-w-[220px]">
+              <Shimmer className="h-3 w-20" />
+            </th>
+            {Array.from({ length: cols }).map((_, i) => (
+              <th key={i} className="px-3 py-2 text-right">
+                <Shimmer className="h-3 w-8 ml-auto" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: rows }).map((_, rowIdx) => (
+            <tr key={rowIdx} className="border-t border-[#f0f0f0]">
+              <td className="px-3 py-[10px]">
+                <Shimmer className={`h-3 ${rowIdx % 3 === 0 ? 'w-44' : rowIdx % 3 === 1 ? 'w-32' : 'w-36'}`} />
+              </td>
+              {Array.from({ length: cols }).map((_, colIdx) => (
+                <td key={colIdx} className="px-3 py-[10px] text-right">
+                  <Shimmer
+                    className={`h-3 ml-auto ${colIdx % 2 === 0 ? 'w-14' : 'w-10'}`}
+                    style={{ animationDelay: `${(rowIdx + colIdx) * 60}ms` } as React.CSSProperties}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </>
+);

--- a/src/screens/RelatorioP1A/components/P1aModeloTab.tsx
+++ b/src/screens/RelatorioP1A/components/P1aModeloTab.tsx
@@ -1,0 +1,172 @@
+import React, { useMemo } from 'react';
+import { ModeloRow } from '../types';
+import { nomeExibidor, ordenarExibidores } from '../utils/exibidores';
+import { fmt2, fmtBRL, fmtInt, fmtPct, toNum } from '../utils/formatters';
+import { P1aTableSkeleton } from './P1aLoader';
+
+interface P1aModeloTabProps {
+  rows: ModeloRow[];
+  loading?: boolean;
+  hasSimulatedPlans?: boolean;
+}
+
+interface ColunaMetrica {
+  label: string;
+  field: keyof ModeloRow;
+  format: (value: unknown) => string;
+}
+
+const COLUNAS_METRICA: ColunaMetrica[] = [
+  { label: 'Investimento', field: 'investimento_vl', format: fmtBRL },
+  { label: 'Cob%', field: 'coberturaProp_vl', format: fmtPct },
+  { label: 'Freq.', field: 'frequencia_vl', format: fmt2 },
+  { label: 'Faces', field: 'faces_vl', format: fmtInt },
+  { label: 'Alcance', field: 'alcance_vl', format: fmtInt },
+  { label: 'Impressões Qual.', field: 'impressoesQualificadas_vl', format: fmtInt },
+];
+
+export const P1aModeloTab: React.FC<P1aModeloTabProps> = ({ rows, loading, hasSimulatedPlans }) => {
+  const blocos = useMemo(() => {
+    const byDim = new Map<string, ModeloRow[]>();
+    rows.forEach((row) => {
+      const k = (row.dimensionValue_st as string) || '—';
+      const arr = byDim.get(k) || [];
+      arr.push(row);
+      byDim.set(k, arr);
+    });
+
+    return Array.from(byDim.entries())
+      .sort((a, b) => a[0].localeCompare(b[0], 'pt-BR'))
+      .map(([dimVal, dimRows]) => {
+        const semanas = Array.from(
+          new Set(
+            dimRows
+              .map((r) => toNum(r.week_vl))
+              .filter((v): v is number => v !== null),
+          ),
+        ).sort((a, b) => a - b);
+        const exibidores = ordenarExibidores(dimRows.map((r) => r.exibidorP1a_st));
+
+        const idx = new Map<string, Map<number, ModeloRow>>();
+        dimRows.forEach((r) => {
+          const e = nomeExibidor(r.exibidorP1a_st);
+          const w = toNum(r.week_vl);
+          if (w === null) return;
+          let m = idx.get(e);
+          if (!m) {
+            m = new Map();
+            idx.set(e, m);
+          }
+          m.set(w, r);
+        });
+
+        return { dimVal, semanas, exibidores, idx };
+      });
+  }, [rows]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <P1aTableSkeleton rows={4} cols={7} />
+      </div>
+    );
+  }
+
+  if (blocos.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-[#ededed] p-12 text-center text-[#757575]">
+        Selecione um ou mais roteiros para visualizar o Modelo P1A.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {hasSimulatedPlans && (
+        <div className="rounded-lg border border-[#ffd87a] bg-[#fff8e1] px-4 py-3 text-sm text-[#8a6d00]">
+          <strong>Atenção:</strong> a seleção contém roteiros simulados — colunas de
+          investimento podem vir zeradas. Métricas físicas (cobertura, frequência, faces,
+          alcance, impressões qualificadas) são válidas.
+        </div>
+      )}
+
+      {blocos.map(({ dimVal, semanas, exibidores, idx }) => (
+        <div key={dimVal} className="bg-white rounded-lg border border-[#ededed] overflow-hidden">
+          <div className="bg-[#fff5ef] border-b border-[#ffd9c4] px-4 py-2">
+            <span className="text-sm font-semibold text-[#3a3a3a]">{dimVal}</span>
+          </div>
+
+          <div className="overflow-auto">
+            <table className="text-sm border-collapse">
+              <thead>
+                <tr className="bg-[#f8f8f8]">
+                  <th
+                    rowSpan={2}
+                    className="px-3 py-2 text-left text-xs uppercase tracking-wide text-[#757575] sticky left-0 bg-[#f8f8f8] border-r border-[#ededed] min-w-[80px]"
+                  >
+                    Semana
+                  </th>
+                  {exibidores.map((ex) => (
+                    <th
+                      key={ex}
+                      colSpan={COLUNAS_METRICA.length}
+                      className={`px-3 py-2 text-center text-xs uppercase tracking-wide border-r border-[#ededed] ${
+                        ex.toLowerCase() === 'demais ooh'
+                          ? 'bg-[#ededed] text-[#3a3a3a]'
+                          : ex.toLowerCase() === 'não informado'
+                          ? 'bg-[#fff8e1] text-[#8a6d00]'
+                          : 'bg-[#fff5ef] text-[#ff4600]'
+                      } font-bold`}
+                    >
+                      {ex}
+                    </th>
+                  ))}
+                </tr>
+                <tr className="bg-[#fafafa]">
+                  {exibidores.flatMap((ex) =>
+                    COLUNAS_METRICA.map((c, idxCol) => (
+                      <th
+                        key={`${ex}-${c.label}`}
+                        className={`px-2 py-1.5 text-right text-[10px] uppercase tracking-wide text-[#757575] ${
+                          idxCol === COLUNAS_METRICA.length - 1
+                            ? 'border-r border-[#ededed]'
+                            : ''
+                        }`}
+                      >
+                        {c.label}
+                      </th>
+                    )),
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {semanas.map((s) => (
+                  <tr key={s} className="border-t border-[#f0f0f0] hover:bg-[#fafafa]">
+                    <td className="px-3 py-2 font-mono text-xs text-[#3a3a3a] sticky left-0 bg-white border-r border-[#ededed]">
+                      W{s}
+                    </td>
+                    {exibidores.flatMap((ex) => {
+                      const row = idx.get(ex)?.get(s);
+                      return COLUNAS_METRICA.map((c, idxCol) => (
+                        <td
+                          key={`${ex}-${c.label}-${s}`}
+                          className={`px-2 py-2 text-right font-mono text-xs ${
+                            idxCol === COLUNAS_METRICA.length - 1
+                              ? 'border-r border-[#ededed]'
+                              : ''
+                          }`}
+                        >
+                          {row ? c.format(row[c.field]) : '—'}
+                        </td>
+                      ));
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/screens/RelatorioP1A/components/P1aReportSelector.tsx
+++ b/src/screens/RelatorioP1A/components/P1aReportSelector.tsx
@@ -1,0 +1,228 @@
+import React, { useMemo, useState } from 'react';
+import { ReportOption } from '../types';
+import { formatDateBr } from '../utils/formatters';
+
+interface P1aReportSelectorProps {
+  reports: ReportOption[];
+  selected: number[];
+  onChange: (next: number[]) => void;
+  loading?: boolean;
+}
+
+export const P1aReportSelector: React.FC<P1aReportSelectorProps> = ({
+  reports,
+  selected,
+  onChange,
+  loading,
+}) => {
+  const [aberto, setAberto] = useState(false);
+  const [busca, setBusca] = useState('');
+  const [filtroUsuario, setFiltroUsuario] = useState<string>('');
+
+  const usuarios = useMemo(() => {
+    const set = new Set<string>();
+    reports.forEach((r) => {
+      if (r.usuarioName_st) set.add(r.usuarioName_st);
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+  }, [reports]);
+
+  const filtrados = useMemo(() => {
+    const termo = busca.trim().toLowerCase();
+    return reports.filter((r) => {
+      if (filtroUsuario && r.usuarioName_st !== filtroUsuario) return false;
+      if (!termo) return true;
+      const haystack = [
+        r.planoMidiaGrupo_pk,
+        r.planoMidiaGrupo_st,
+        r.marca_st,
+        r.agencia_st,
+        r.cidadeUpper_st_concat,
+        r.usuarioName_st,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(termo);
+    });
+  }, [reports, busca, filtroUsuario]);
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const toggle = (pk: number) => {
+    if (selectedSet.has(pk)) {
+      onChange(selected.filter((s) => s !== pk));
+    } else {
+      onChange([...selected, pk]);
+    }
+  };
+
+  const marcarVisiveis = () => {
+    const ids = new Set(selected);
+    filtrados.forEach((r) => ids.add(r.planoMidiaGrupo_pk));
+    onChange(Array.from(ids));
+  };
+
+  const limpar = () => onChange([]);
+
+  const resumo =
+    selected.length === 0
+      ? 'Selecionar roteiros'
+      : selected.length === 1
+      ? `1 roteiro selecionado`
+      : `${selected.length} roteiros selecionados`;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setAberto((v) => !v)}
+        className={`w-full flex items-center justify-between gap-2 h-[44px] px-4 rounded-lg border bg-white text-left transition-colors ${
+          aberto
+            ? 'border-[#ff4600] ring-2 ring-[#ff4600]/20'
+            : 'border-[#d9d9d9] hover:border-[#bbb]'
+        }`}
+      >
+        <span
+          className={`text-sm truncate ${
+            selected.length > 0 ? 'text-[#222]' : 'text-[#757575]'
+          }`}
+        >
+          {resumo}
+        </span>
+        <svg
+          className={`w-4 h-4 text-[#757575] transition-transform ${
+            aberto ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {aberto && (
+        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-[#d9d9d9] rounded-lg shadow-xl z-30 max-h-[520px] flex flex-col">
+          <div className="p-3 border-b border-[#ededed] flex flex-col gap-2">
+            <input
+              type="text"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              placeholder="Buscar por PK, nome, marca, agência, cidade..."
+              className="w-full h-[36px] px-3 rounded-md border border-[#d9d9d9] focus:outline-none focus:ring-2 focus:ring-[#ff4600]/30 focus:border-[#ff4600] text-sm"
+            />
+            <div className="flex items-center gap-2">
+              <select
+                value={filtroUsuario}
+                onChange={(e) => setFiltroUsuario(e.target.value)}
+                className="h-[32px] px-2 rounded-md border border-[#d9d9d9] text-sm text-[#3a3a3a] flex-1"
+              >
+                <option value="">Todos os usuários</option>
+                {usuarios.map((u) => (
+                  <option key={u} value={u}>
+                    {u}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={marcarVisiveis}
+                className="text-xs px-2 py-1 rounded border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a]"
+                disabled={filtrados.length === 0}
+              >
+                Marcar visíveis
+              </button>
+              <button
+                type="button"
+                onClick={limpar}
+                className="text-xs px-2 py-1 rounded border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a]"
+                disabled={selected.length === 0}
+              >
+                Limpar
+              </button>
+            </div>
+            <div className="text-xs text-[#757575]">
+              {filtrados.length} de {reports.length} roteiros · {selected.length} selecionados
+            </div>
+          </div>
+
+          <div className="overflow-auto flex-1">
+            {loading ? (
+              <div className="p-4 text-center text-sm text-[#757575]">Carregando roteiros…</div>
+            ) : filtrados.length === 0 ? (
+              <div className="p-4 text-center text-sm text-[#757575]">Nenhum roteiro encontrado.</div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-[#f8f8f8] text-left text-xs uppercase tracking-wide text-[#757575]">
+                  <tr>
+                    <th className="px-3 py-2 w-[40px]"></th>
+                    <th className="px-2 py-2">PK</th>
+                    <th className="px-2 py-2">Nome</th>
+                    <th className="px-2 py-2">Usuário</th>
+                    <th className="px-2 py-2">Cidade(s)</th>
+                    <th className="px-2 py-2">Sem</th>
+                    <th className="px-2 py-2">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtrados.map((r) => {
+                    const checked = selectedSet.has(r.planoMidiaGrupo_pk);
+                    return (
+                      <tr
+                        key={r.planoMidiaGrupo_pk}
+                        onClick={() => toggle(r.planoMidiaGrupo_pk)}
+                        className={`cursor-pointer border-t border-[#f0f0f0] hover:bg-[#fafafa] ${
+                          checked ? 'bg-[#fff5ef]' : ''
+                        }`}
+                      >
+                        <td className="px-3 py-2">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) => {
+                              e.stopPropagation();
+                              toggle(r.planoMidiaGrupo_pk);
+                            }}
+                            className="accent-[#ff4600]"
+                          />
+                        </td>
+                        <td className="px-2 py-2 font-mono text-xs text-[#3a3a3a]">
+                          {r.planoMidiaGrupo_pk}
+                        </td>
+                        <td className="px-2 py-2 text-[#222]">{r.planoMidiaGrupo_st}</td>
+                        <td className="px-2 py-2 text-[#3a3a3a]">{r.usuarioName_st || '—'}</td>
+                        <td className="px-2 py-2 text-[#3a3a3a] truncate max-w-[200px]">
+                          {r.cidadeUpper_st_concat || '—'}
+                        </td>
+                        <td className="px-2 py-2 text-[#3a3a3a]">{r.semanasMax_vl ?? '—'}</td>
+                        <td className="px-2 py-2 text-xs text-[#757575] whitespace-nowrap">
+                          {formatDateBr(r.date_dh)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          <div className="p-2 border-t border-[#ededed] flex justify-end">
+            <button
+              type="button"
+              onClick={() => setAberto(false)}
+              className="px-3 py-1.5 text-sm rounded-md bg-[#ff4600] text-white hover:bg-[#e63d00]"
+            >
+              Concluir
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/screens/RelatorioP1A/index.ts
+++ b/src/screens/RelatorioP1A/index.ts
@@ -1,0 +1,1 @@
+export { RelatorioP1A } from './RelatorioP1A';

--- a/src/screens/RelatorioP1A/types.ts
+++ b/src/screens/RelatorioP1A/types.ts
@@ -1,0 +1,145 @@
+export type Dimension = 'GEO' | 'PRACA' | 'UF';
+export type Negociacao = 'TOTAL' | 'FATURAVEL' | 'NAO_FATURAVEL';
+export type SourceType = 'import' | 'colmeia' | 'skipped' | null;
+export type P1aTab = 'colmeia' | 'exibidor' | 'modelo';
+
+/** Linha do `planoMidiaGrupo_dm_vw` exposta pelo `/api/relatorio-p1a-options`. */
+export interface ReportOption {
+  _pk: number;
+  planoMidiaGrupo_pk: number;
+  planoMidiaGrupo_st: string;
+  planoMidiaDesc_st_concat: string | null;
+  usuarioId_st: string | null;
+  usuarioName_st: string | null;
+  gender_st: string | null;
+  class_st: string | null;
+  age_st: string | null;
+  planoMidiaType_st: string | null;
+  cidadeUpper_st_concat: string | null;
+  semanasMax_vl: number | null;
+  date_dh: string;
+  agencia_st: string | null;
+  liberadoAgencia_bl: number | null;
+  marca_st?: string | null;
+}
+
+export interface OptionsResponse {
+  reports: ReportOption[];
+  marcas: string[];
+  dimensions: Record<Dimension, string[]>;
+  negociacoes: Negociacao[];
+}
+
+export interface RefreshRow {
+  report_pk: number;
+  refreshedAt_dh: string;
+  rowsWritten_vl: number;
+  skipped_bl: number | boolean;
+  sourceType_st: SourceType;
+}
+
+/**
+ * Aba 5 — Colmeia. Recordset real de `sp_reportResultColmeiaGeoClosed`.
+ * Uma linha por (dimensionValue × week) com todas as métricas em colunas.
+ */
+export interface ColmeiaRow {
+  planoMidiaGrupoPk_st?: string | null;
+  dimension_st?: Dimension | string | null;
+  dimensionValue_st?: string | null;
+  geoAmbev_st?: string | null;
+  week_vl: number | string;
+  impactosIpv_vl?: number | string | null;
+  coberturaProp_vl?: number | string | null;
+  coberturaPessoas_vl?: number | string | null;
+  populationTotal_vl?: number | string | null;
+  pontosPraca_vl?: number | string | null;
+  pontos_vl?: number | string | null;
+  dominacao_vl?: number | string | null;
+  segmento_st?: string | null;
+  deflatorInventario_vl?: number | string | null;
+  frequenciaTeorica_vl?: number | string | null;
+  frequencia_vl?: number | string | null;
+  grp_vl?: number | string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Aba 6 — Exibidor. Recordset real de
+ * `sp_reportResultExibidor{Geo,Praca,Uf}Closed`. Uma linha por
+ * (dimensionValue × week × exibidorP1a) — os campos `*Sheet_vl` são os
+ * totais agregados que alimentam o bloco "TOTAL" da UI.
+ */
+export interface ExibidorRow {
+  planoMidiaGrupoPk_st?: string | null;
+  dimension_st?: string | null;
+  dimensionValue_st?: string | null;
+  week_vl: number | string;
+  exibidorP1a_st?: string | null;
+
+  // Métricas por exibidor (físicas e financeiras)
+  facesViasPublicas_vl?: number | string | null;
+  facesTotal_vl?: number | string | null;
+  facesFaturaveis_vl?: number | string | null;
+  facesNaoFaturaveis_vl?: number | string | null;
+  localidadesIndoor_vl?: number | string | null;
+  localidadesIndoorFaturaveis_vl?: number | string | null;
+  localidadesIndoorNaoFaturaveis_vl?: number | string | null;
+  impactosIndoor_vl?: number | string | null;
+  impactosViasPublicas_vl?: number | string | null;
+  impactosTotal_vl?: number | string | null;
+  pctFaces_vl?: number | string | null;
+  investimento_vl?: number | string | null;
+  coberturaProp_vl?: number | string | null;
+  coberturaPessoas_vl?: number | string | null;
+  frequencia_vl?: number | string | null;
+  impressoesQualificadas_vl?: number | string | null;
+
+  // Totais "Sheet" — usados no bloco TOTAL
+  facesTotalSheet_vl?: number | string | null;
+  localidadesIndoorTotalSheet_vl?: number | string | null;
+  impactosTotalSheet_vl?: number | string | null;
+  coberturaPropTotalSheet_vl?: number | string | null;
+  populationTotalSheet_vl?: number | string | null;
+  pontosSheet_vl?: number | string | null;
+  pontosPracaSheet_vl?: number | string | null;
+
+  segmento_st?: string | null;
+  dominacao_vl?: number | string | null;
+
+  [key: string]: unknown;
+}
+
+/**
+ * Aba 7 — Modelo P1A. Recordset real de `sp_reportResultP1aBase`.
+ * Plano (week × exibidor) — pivot é feito no cliente.
+ */
+export interface ModeloRow {
+  planoMidiaGrupoPk_st?: string | null;
+  dimensionType_st?: string | null;
+  dimensionValue_st?: string | null;
+  week_vl: number | string;
+  exibidorP1a_st?: string | null;
+  investimento_vl?: number | string | null;
+  coberturaProp_vl?: number | string | null;
+  frequencia_vl?: number | string | null;
+  faces_vl?: number | string | null;
+  alcance_vl?: number | string | null;
+  impressoesQualificadas_vl?: number | string | null;
+  [key: string]: unknown;
+}
+
+export interface P1aFilters {
+  reportPks: number[];
+  dimension: Dimension;
+  dimensionValue: string | null;
+  marca: string | null;
+  negociacao: Negociacao;
+}
+
+export const DEFAULT_FILTERS: P1aFilters = {
+  reportPks: [],
+  dimension: 'GEO',
+  dimensionValue: null,
+  marca: null,
+  negociacao: 'TOTAL',
+};

--- a/src/screens/RelatorioP1A/utils/exibidores.ts
+++ b/src/screens/RelatorioP1A/utils/exibidores.ts
@@ -1,0 +1,64 @@
+/**
+ * Regra de ordenação de exibidores nas abas Exibidor e Modelo P1A.
+ *  1. Exibidores prioritários, em ordem fixa
+ *  2. Demais exibidores em ordem alfabética
+ *  3. "Demais OOH" sempre por último
+ *  4. Linhas com `exibidorP1a_st` null/vazio são rotuladas como
+ *     "Não informado" e ficam ao final, antes de "Demais OOH".
+ */
+const PRIORIDADE_ORDEM = ['Jcdecaux', 'Eletromidia', 'Urbia', 'Pacote banka'];
+const DEMAIS_OOH = 'Demais OOH';
+export const NAO_INFORMADO = 'Não informado';
+
+function normalize(name: string): string {
+  return (name || '').trim().toLowerCase();
+}
+
+export function nomeExibidor(value: string | null | undefined): string {
+  if (!value || !value.trim()) return NAO_INFORMADO;
+  return value;
+}
+
+export function ordenarExibidores(nomes: Array<string | null | undefined>): string[] {
+  const set = new Set<string>();
+  nomes.forEach((n) => {
+    const nome = nomeExibidor(n);
+    if (nome) set.add(nome);
+  });
+
+  const prioritarios: string[] = [];
+  const demais: string[] = [];
+  let temDemaisOOH = false;
+  let temNaoInformado = false;
+
+  set.forEach((nome) => {
+    const n = normalize(nome);
+    if (n === normalize(NAO_INFORMADO)) {
+      temNaoInformado = true;
+      return;
+    }
+    if (n === normalize(DEMAIS_OOH)) {
+      temDemaisOOH = true;
+      return;
+    }
+    const matchPrior = PRIORIDADE_ORDEM.find((p) => normalize(p) === n);
+    if (matchPrior) {
+      prioritarios.push(nome);
+      return;
+    }
+    demais.push(nome);
+  });
+
+  prioritarios.sort((a, b) => {
+    const ia = PRIORIDADE_ORDEM.findIndex((p) => normalize(p) === normalize(a));
+    const ib = PRIORIDADE_ORDEM.findIndex((p) => normalize(p) === normalize(b));
+    return ia - ib;
+  });
+
+  demais.sort((a, b) => a.localeCompare(b, 'pt-BR'));
+
+  const result = [...prioritarios, ...demais];
+  if (temNaoInformado) result.push(NAO_INFORMADO);
+  if (temDemaisOOH) result.push(DEMAIS_OOH);
+  return result;
+}

--- a/src/screens/RelatorioP1A/utils/exportXlsx.ts
+++ b/src/screens/RelatorioP1A/utils/exportXlsx.ts
@@ -1,0 +1,69 @@
+import * as XLSX from 'xlsx';
+import { ColmeiaRow, Dimension, ExibidorRow, ModeloRow } from '../types';
+
+interface ExportArgs {
+  filename?: string;
+  dimension: Dimension;
+  dimensionValue: string | null;
+  colmeiaRows: ColmeiaRow[];
+  exibidorRows: ExibidorRow[];
+  modeloRows: ModeloRow[];
+}
+
+/**
+ * Exporta as 3 abas + abas "(raw)" do Relatório P1A em um único .xlsx.
+ *
+ * Versão "simples" usando a lib `xlsx` que já temos no projeto. Não traz
+ * cores/merges/freeze do workbook original — esse enriquecimento pode ser
+ * adicionado em fase futura (com `xlsx-js-style` ou `exceljs`).
+ */
+export function exportP1aWorkbook({
+  filename,
+  dimension,
+  dimensionValue,
+  colmeiaRows,
+  exibidorRows,
+  modeloRows,
+}: ExportArgs) {
+  const wb = XLSX.utils.book_new();
+
+  if (colmeiaRows.length > 0) {
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.json_to_sheet(colmeiaRows),
+      truncSheetName('5 Colmeia (raw)'),
+    );
+  }
+  if (exibidorRows.length > 0) {
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.json_to_sheet(exibidorRows),
+      truncSheetName('6 Exibidor (raw)'),
+    );
+  }
+  if (modeloRows.length > 0) {
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.json_to_sheet(modeloRows),
+      truncSheetName('7 Modelo P1A (raw)'),
+    );
+  }
+
+  if (wb.SheetNames.length === 0) {
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.json_to_sheet([{ aviso: 'Sem dados para exportar' }]),
+      'Vazio',
+    );
+  }
+
+  const safeDim = dimensionValue ? `_${dimensionValue.replace(/[^\w]+/g, '-')}` : '';
+  const finalName =
+    filename || `Relatorio_P1A_${dimension}${safeDim}_${new Date().toISOString().slice(0, 10)}.xlsx`;
+  XLSX.writeFile(wb, finalName);
+}
+
+function truncSheetName(name: string): string {
+  // Excel limita a 31 caracteres
+  return name.length > 31 ? name.slice(0, 31) : name;
+}

--- a/src/screens/RelatorioP1A/utils/formatters.ts
+++ b/src/screens/RelatorioP1A/utils/formatters.ts
@@ -1,0 +1,69 @@
+/**
+ * Formatadores pt-BR centralizados para o Relatório P1A. Mantemos o mesmo
+ * padrão visual usado no Excel original (workbook P1A_fev26).
+ *
+ * IMPORTANTE: vários campos retornados pelas SPs vêm como string
+ * (ex.: bigints e decimais — `populationTotal_vl: "2417678"`,
+ * `coberturaPessoas_vl: "143402"`). Por isso `toNum()` aceita unknown e
+ * normaliza antes de aplicar `Intl.NumberFormat`.
+ */
+const NF_INT = new Intl.NumberFormat('pt-BR', {
+  maximumFractionDigits: 0,
+});
+const NF_2DEC = new Intl.NumberFormat('pt-BR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+const NF_4DEC = new Intl.NumberFormat('pt-BR', {
+  minimumFractionDigits: 4,
+  maximumFractionDigits: 4,
+});
+const NF_BRL = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+});
+
+export function toNum(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function fmtInt(value: unknown): string {
+  const n = toNum(value);
+  return n === null ? '—' : NF_INT.format(n);
+}
+
+export function fmt2(value: unknown): string {
+  const n = toNum(value);
+  return n === null ? '—' : NF_2DEC.format(n);
+}
+
+export function fmt4(value: unknown): string {
+  const n = toNum(value);
+  return n === null ? '—' : NF_4DEC.format(n);
+}
+
+export function fmtBRL(value: unknown): string {
+  const n = toNum(value);
+  return n === null ? '—' : NF_BRL.format(n);
+}
+
+/** Recebe fração (0..1) e devolve "X,YY%". */
+export function fmtPct(value: unknown): string {
+  const n = toNum(value);
+  return n === null ? '—' : `${NF_2DEC.format(n * 100)}%`;
+}
+
+export function formatDateBr(input: string | null | undefined): string {
+  if (!input) return '—';
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,8 @@
     { "source": "/exibidor/:path*", "destination": "/index.html" },
     { "source": "/banco-de-ativos", "destination": "/index.html" },
     { "source": "/banco-de-ativos/:path*", "destination": "/index.html" },
+    { "source": "/relatorio-p1a", "destination": "/index.html" },
+    { "source": "/relatorio-p1a/:path*", "destination": "/index.html" },
     { "source": "/admin/:path*", "destination": "/index.html" },
 
     { "source": "/api/roteiros-search", "destination": "/api/roteiros?action=search" },
@@ -79,6 +81,12 @@
     { "source": "/banco-ativos-relatorio-praca",       "destination": "/api/banco-ativos?action=relatorio-praca" },
     { "source": "/api/banco-ativos-relatorio-exibidor","destination": "/api/banco-ativos?action=relatorio-exibidor" },
     { "source": "/banco-ativos-relatorio-exibidor",    "destination": "/api/banco-ativos?action=relatorio-exibidor" },
+
+    { "source": "/api/relatorio-p1a-options",  "destination": "/api/relatorio-p1a?action=options"  },
+    { "source": "/api/relatorio-p1a-refresh",  "destination": "/api/relatorio-p1a?action=refresh"  },
+    { "source": "/api/relatorio-p1a-colmeia",  "destination": "/api/relatorio-p1a?action=colmeia"  },
+    { "source": "/api/relatorio-p1a-exibidor", "destination": "/api/relatorio-p1a?action=exibidor" },
+    { "source": "/api/relatorio-p1a-modelo",   "destination": "/api/relatorio-p1a?action=modelo"   },
 
     { "source": "/api/agencia", "destination": "/api/referencia?action=agencia" },
     { "source": "/api/marca", "destination": "/api/referencia?action=marca" },


### PR DESCRIPTION
- Sidebar: novo item "Relatório P1A" (raiz, abaixo de Meus roteiros)
- Rota /relatorio-p1a registrada no React Router e no vercel.json
- Backend: api/relatorio-p1a.js (dispatcher) + 5 handlers • relatorio-p1a-options: lista planoMidiaGrupo_dm_vw com filtro de agência + DISTINCTs escopados (marca, geoAmbev, cidade, estado) do stage • relatorio-p1a-refresh: sp_reportDataP1aEmpilhamentoRefresh (mapeado force→skipIfFresherThanMinutes_vl=0) • relatorio-p1a-colmeia: sp_reportResultColmeiaGeoClosed (aba 5) • relatorio-p1a-exibidor: sp_reportResultExibidor{Geo,Praca,Uf}Closed (aba 6) • relatorio-p1a-modelo: sp_reportResultP1aBase (aba 7) • relatorio-p1a-utils: normalizePks / extractReportPksCsv / normalizeDimension / normalizeNegociacao
- Frontend: src/screens/RelatorioP1A/ • Tipos reais dos recordsets (week_vl, exibidorP1a_st, coberturaProp_vl…) • P1aReportSelector: multi-select com busca e filtro por usuário • P1aFiltersBar: marca · dimensão · valor · negociação • P1aColmeiaTab: matriz (dimVal × week) com 11 métricas reais + badge segmento • P1aExibidorTab: bloco TOTAL (*Sheet_vl) + por exibidor (14 métricas) com ordenação fixa (Jcdecaux→Eletromidia→Urbia→Pacote banka→alfa→Demais OOH) • P1aModeloTab: pivot week × exibidor × 6 métricas • Banner de planos simulados (sourceType_st=colmeia) • Export .xlsx simples (3 abas raw) via xlsx • P1aRefreshLoader: etapas animadas durante o refresh do stage (~4s) • P1aTableSkeleton: shimmer que imita a estrutura real da tabela • Deep-link por querystring (?reportPks=&dim=&dimVal=&marca=&neg=&tab=)
- vercel.json: 5 rewrites /api/relatorio-p1a-* + 2 rewrites de SPA