### PR TITLE
feat(p1a): export empilhado — dados brutos do stage com informações c…

### DIFF
--- a/api/relatorio-p1a.js
+++ b/api/relatorio-p1a.js
@@ -4,6 +4,7 @@ const handlers = {
   colmeia: require('../handlers/relatorio-p1a-colmeia'),
   exibidor: require('../handlers/relatorio-p1a-exibidor'),
   modelo: require('../handlers/relatorio-p1a-modelo'),
+  empilhamento: require('../handlers/relatorio-p1a-empilhamento'),
 };
 
 module.exports = async (req, res) => {

--- a/handlers/relatorio-p1a-empilhamento.js
+++ b/handlers/relatorio-p1a-empilhamento.js
@@ -1,0 +1,94 @@
+/**
+ * POST /api/relatorio-p1a-empilhamento
+ *
+ * Retorna todas as linhas do stage `reportDataP1aEmpilhamento_dm`
+ * para os roteiros selecionados, enriquecidas com o nome do roteiro
+ * (`planoMidiaGrupo_st`) e data de criação (`date_dh`) vindos de
+ * `planoMidiaGrupo_dm_vw`. É o insumo bruto para o export "empilhado".
+ *
+ * Body: { reportPks: number[] | string | number }
+ *
+ * Colunas retornadas (em ordem amigável para o Excel):
+ *   report_pk, planoMidiaGrupo_st, date_dh (do grupo),
+ *   + todas as colunas do stage (week_vl, weekDate_dt, marca_st,
+ *     campanha_st, produto_st, cidade_st, estado_st, geoAmbev_st,
+ *     exibidorRaw_st, exibidorP1a_st, tipoP1a_st, negociacaoP1a_st,
+ *     faturavel_bl, weekCount_vl, facesViasPublicas_vl,
+ *     localidadeIndoor_vl, investimento_vl, impactosIndoor_vl,
+ *     valorLiquido_vl, ttFaces_vl, divisorFlightFace_vl, impactoIpv_vl,
+ *     sourceType_st — se existir, refreshedAt_dh)
+ */
+const { sql, getPool } = require('./db');
+const { extractReportPksCsv } = require('./relatorio-p1a-utils');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const { csv, error } = extractReportPksCsv(req.body);
+    if (error) return res.status(400).json({ error });
+
+    const pool = await getPool();
+
+    const result = await pool
+      .request()
+      .input('pks', sql.NVarChar(sql.MAX), csv)
+      .query(`
+        DECLARE @t TABLE (report_pk INT);
+        INSERT INTO @t (report_pk)
+        SELECT TRY_CAST(value AS INT)
+        FROM STRING_SPLIT(@pks, ',')
+        WHERE TRY_CAST(value AS INT) IS NOT NULL;
+
+        SELECT
+          e.report_pk                        AS [Roteiro PK],
+          g.planoMidiaGrupo_st               AS [Nome do roteiro],
+          g.usuarioName_st                   AS [Usuário],
+          g.agencia_st                       AS [Agência],
+          g.date_dh                          AS [Data criação roteiro],
+          e.week_vl                          AS [Semana],
+          e.weekDate_dt                      AS [Data da semana],
+          e.marca_st                         AS [Marca],
+          e.campanha_st                      AS [Campanha],
+          e.produto_st                       AS [Produto],
+          e.cidade_st                        AS [Cidade],
+          e.estado_st                        AS [UF],
+          e.geoAmbev_st                      AS [GEO],
+          e.exibidorRaw_st                   AS [Exibidor (raw)],
+          e.exibidorP1a_st                   AS [Exibidor P1A],
+          e.tipoP1a_st                       AS [Tipo P1A],
+          e.negociacaoP1a_st                 AS [Negociação P1A],
+          e.faturavel_bl                     AS [Faturável],
+          e.weekCount_vl                     AS [Qtd semanas (flight)],
+          e.facesViasPublicas_vl             AS [Faces vias públicas],
+          e.localidadeIndoor_vl              AS [Localidades indoor],
+          e.investimento_vl                  AS [Investimento],
+          e.impactosIndoor_vl                AS [Impactos indoor],
+          e.valorLiquido_vl                  AS [Valor líquido],
+          e.ttFaces_vl                       AS [Total faces (TT)],
+          e.divisorFlightFace_vl             AS [Divisor flight/face],
+          e.impactoIpv_vl                    AS [Impacto IPV],
+          e.refreshedAt_dh                   AS [Atualizado em (stage)]
+        FROM [serv_product_be180].[reportDataP1aEmpilhamento_dm] e
+        LEFT JOIN [serv_product_be180].[planoMidiaGrupo_dm_vw] g
+          ON g.planoMidiaGrupo_pk = e.report_pk
+        WHERE e.report_pk IN (SELECT report_pk FROM @t)
+        ORDER BY
+          e.report_pk,
+          e.week_vl,
+          e.geoAmbev_st,
+          e.exibidorP1a_st
+      `);
+
+    console.log(
+      `📊 [relatorio-p1a-empilhamento] pks=${csv} → ${result.recordset.length} linhas`,
+    );
+
+    return res.status(200).json({ rows: result.recordset || [] });
+  } catch (err) {
+    console.error('❌ [relatorio-p1a-empilhamento] Erro:', err);
+    return res.status(500).json({ error: err.message || 'Erro ao buscar dados empilhados' });
+  }
+};

--- a/src/screens/RelatorioP1A/RelatorioP1A.tsx
+++ b/src/screens/RelatorioP1A/RelatorioP1A.tsx
@@ -9,7 +9,7 @@ import { P1aColmeiaTab } from './components/P1aColmeiaTab';
 import { P1aExibidorTab } from './components/P1aExibidorTab';
 import { P1aModeloTab } from './components/P1aModeloTab';
 import { P1aRefreshLoader } from './components/P1aLoader';
-import { exportP1aWorkbook } from './utils/exportXlsx';
+import { exportP1aWorkbook, exportP1aEmpilhado, EmpilhadoRow } from './utils/exportXlsx';
 import { formatDateBr } from './utils/formatters';
 import {
   ColmeiaRow,
@@ -90,6 +90,7 @@ export const RelatorioP1A: React.FC = () => {
 
   const [erro, setErro] = useState<string | null>(null);
   const [exportando, setExportando] = useState(false);
+  const [exportandoEmpilhado, setExportandoEmpilhado] = useState(false);
 
   const selectedKey = pksKey(filters.reportPks);
 
@@ -259,6 +260,27 @@ export const RelatorioP1A: React.FC = () => {
     }
   }, [filters.reportPks, fetchColmeia, fetchExibidor, fetchModelo]);
 
+  const handleExportEmpilhado = useCallback(async () => {
+    if (filters.reportPks.length === 0) return;
+    try {
+      setExportandoEmpilhado(true);
+      setErro(null);
+      const resp = await api.post('/relatorio-p1a-empilhamento', {
+        reportPks: filters.reportPks,
+      });
+      const rows: EmpilhadoRow[] = resp.data?.rows || [];
+      if (rows.length === 0) {
+        setErro('Nenhum dado empilhado encontrado. Verifique se os roteiros já foram atualizados.');
+        return;
+      }
+      exportP1aEmpilhado(rows, filters.reportPks);
+    } catch (err: any) {
+      setErro(err?.response?.data?.error || 'Erro ao exportar dados empilhados');
+    } finally {
+      setExportandoEmpilhado(false);
+    }
+  }, [filters.reportPks]);
+
   const handleExport = useCallback(async () => {
     if (filters.reportPks.length === 0) return;
     try {
@@ -349,7 +371,7 @@ export const RelatorioP1A: React.FC = () => {
                   os filtros para comparar GEO, praça ou UF.
                 </p>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap justify-end">
                 <button
                   type="button"
                   onClick={handleRefreshForcado}
@@ -358,6 +380,33 @@ export const RelatorioP1A: React.FC = () => {
                 >
                   {refreshing ? 'Atualizando…' : 'Atualizar'}
                 </button>
+
+                {/* Export empilhado — dados brutos do stage */}
+                <button
+                  type="button"
+                  onClick={handleExportEmpilhado}
+                  disabled={filters.reportPks.length === 0 || refreshing || exportandoEmpilhado}
+                  title="Exporta todas as linhas do stage (empilhamento) com informações completas para cada roteiro selecionado"
+                  className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-md border border-[#ff4600] text-[#ff4600] hover:bg-[#fff5ef] disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {exportandoEmpilhado ? (
+                    <>
+                      <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                      </svg>
+                      Exportando…
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                      Exportar empilhado
+                    </>
+                  )}
+                </button>
+
+                {/* Export das 3 visões P1A */}
                 <button
                   type="button"
                   onClick={handleExport}
@@ -369,6 +418,7 @@ export const RelatorioP1A: React.FC = () => {
                       exibidorRows.length === 0 &&
                       modeloRows.length === 0)
                   }
+                  title="Exporta as 3 visões do relatório P1A (Colmeia, Exibidor, Modelo)"
                   className="px-3 py-2 text-sm rounded-md bg-[#ff4600] text-white hover:bg-[#e63d00] disabled:opacity-50"
                 >
                   {exportando ? 'Exportando…' : 'Exportar .xlsx'}

--- a/src/screens/RelatorioP1A/utils/exportXlsx.ts
+++ b/src/screens/RelatorioP1A/utils/exportXlsx.ts
@@ -1,6 +1,96 @@
 import * as XLSX from 'xlsx';
 import { ColmeiaRow, Dimension, ExibidorRow, ModeloRow } from '../types';
 
+/* ─────────────────────────────────────────────────────────────────────────────
+   Export "empilhado" — dados brutos do stage para todos os roteiros
+   ───────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Larguras (em caracteres) para cada coluna do export empilhado.
+ * A ordem deve bater com as colunas retornadas pelo handler.
+ */
+const COLUNAS_EMPILHADO: Array<{ key: string; label: string; wch: number }> = [
+  { key: 'Roteiro PK',              label: 'Roteiro PK',              wch: 12  },
+  { key: 'Nome do roteiro',         label: 'Nome do roteiro',         wch: 40  },
+  { key: 'Usuário',                 label: 'Usuário',                 wch: 22  },
+  { key: 'Agência',                 label: 'Agência',                 wch: 22  },
+  { key: 'Data criação roteiro',    label: 'Data criação roteiro',    wch: 22  },
+  { key: 'Semana',                  label: 'Semana',                  wch: 9   },
+  { key: 'Data da semana',          label: 'Data da semana',          wch: 16  },
+  { key: 'Marca',                   label: 'Marca',                   wch: 22  },
+  { key: 'Campanha',                label: 'Campanha',                wch: 30  },
+  { key: 'Produto',                 label: 'Produto',                 wch: 22  },
+  { key: 'Cidade',                  label: 'Cidade',                  wch: 20  },
+  { key: 'UF',                      label: 'UF',                      wch: 6   },
+  { key: 'GEO',                     label: 'GEO',                     wch: 14  },
+  { key: 'Exibidor (raw)',          label: 'Exibidor (raw)',          wch: 22  },
+  { key: 'Exibidor P1A',            label: 'Exibidor P1A',            wch: 20  },
+  { key: 'Tipo P1A',                label: 'Tipo P1A',                wch: 18  },
+  { key: 'Negociação P1A',          label: 'Negociação P1A',          wch: 18  },
+  { key: 'Faturável',               label: 'Faturável',               wch: 10  },
+  { key: 'Qtd semanas (flight)',    label: 'Qtd sem. (flight)',       wch: 16  },
+  { key: 'Faces vias públicas',     label: 'Faces vias públicas',     wch: 18  },
+  { key: 'Localidades indoor',      label: 'Localidades indoor',      wch: 18  },
+  { key: 'Investimento',            label: 'Investimento',            wch: 16  },
+  { key: 'Impactos indoor',         label: 'Impactos indoor',         wch: 16  },
+  { key: 'Valor líquido',           label: 'Valor líquido',           wch: 16  },
+  { key: 'Total faces (TT)',        label: 'Total faces (TT)',        wch: 14  },
+  { key: 'Divisor flight/face',     label: 'Divisor flight/face',     wch: 18  },
+  { key: 'Impacto IPV',             label: 'Impacto IPV',             wch: 16  },
+  { key: 'Atualizado em (stage)',   label: 'Atualizado em (stage)',   wch: 22  },
+];
+
+export interface EmpilhadoRow {
+  [key: string]: unknown;
+}
+
+export function exportP1aEmpilhado(rows: EmpilhadoRow[], reportPks: number[]) {
+  if (rows.length === 0) return;
+
+  const wb = XLSX.utils.book_new();
+
+  // Garante a ordem das colunas e usa labels amigáveis como cabeçalhos
+  const headers = COLUNAS_EMPILHADO.map((c) => c.label);
+  const data: unknown[][] = [headers];
+
+  for (const row of rows) {
+    data.push(
+      COLUNAS_EMPILHADO.map((c) => {
+        const val = row[c.key];
+        if (val === null || val === undefined) return '';
+        // Formatar datas como string legível (evita número serial do Excel)
+        if (
+          typeof val === 'string' &&
+          /^\d{4}-\d{2}-\d{2}T/.test(val)
+        ) {
+          return new Date(val).toLocaleString('pt-BR', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          });
+        }
+        return val;
+      }),
+    );
+  }
+
+  const ws = XLSX.utils.aoa_to_sheet(data);
+
+  // Larguras das colunas
+  ws['!cols'] = COLUNAS_EMPILHADO.map((c) => ({ wch: c.wch }));
+
+  // Freeze na linha de cabeçalho
+  ws['!freeze'] = { xSplit: 0, ySplit: 1 };
+
+  XLSX.utils.book_append_sheet(wb, ws, 'Empilhamento P1A');
+
+  const pksStr = reportPks.slice(0, 5).join('-') + (reportPks.length > 5 ? '-etc' : '');
+  const date = new Date().toISOString().slice(0, 10);
+  XLSX.writeFile(wb, `P1A_Empilhado_${pksStr}_${date}.xlsx`);
+}
+
 interface ExportArgs {
   filename?: string;
   dimension: Dimension;

--- a/vercel.json
+++ b/vercel.json
@@ -82,11 +82,12 @@
     { "source": "/api/banco-ativos-relatorio-exibidor","destination": "/api/banco-ativos?action=relatorio-exibidor" },
     { "source": "/banco-ativos-relatorio-exibidor",    "destination": "/api/banco-ativos?action=relatorio-exibidor" },
 
-    { "source": "/api/relatorio-p1a-options",  "destination": "/api/relatorio-p1a?action=options"  },
-    { "source": "/api/relatorio-p1a-refresh",  "destination": "/api/relatorio-p1a?action=refresh"  },
-    { "source": "/api/relatorio-p1a-colmeia",  "destination": "/api/relatorio-p1a?action=colmeia"  },
-    { "source": "/api/relatorio-p1a-exibidor", "destination": "/api/relatorio-p1a?action=exibidor" },
-    { "source": "/api/relatorio-p1a-modelo",   "destination": "/api/relatorio-p1a?action=modelo"   },
+    { "source": "/api/relatorio-p1a-options",      "destination": "/api/relatorio-p1a?action=options"      },
+    { "source": "/api/relatorio-p1a-refresh",      "destination": "/api/relatorio-p1a?action=refresh"      },
+    { "source": "/api/relatorio-p1a-colmeia",      "destination": "/api/relatorio-p1a?action=colmeia"      },
+    { "source": "/api/relatorio-p1a-exibidor",     "destination": "/api/relatorio-p1a?action=exibidor"     },
+    { "source": "/api/relatorio-p1a-modelo",       "destination": "/api/relatorio-p1a?action=modelo"       },
+    { "source": "/api/relatorio-p1a-empilhamento", "destination": "/api/relatorio-p1a?action=empilhamento" },
 
     { "source": "/api/agencia", "destination": "/api/referencia?action=agencia" },
     { "source": "/api/marca", "destination": "/api/referencia?action=marca" },


### PR DESCRIPTION
…ompletas

Adiciona opção de exportar todos os planos selecionados em formato empilhado com todas as informações disponíveis no stage (reportDataP1aEmpilhamento_dm).

- handlers/relatorio-p1a-empilhamento.js: handler que faz SELECT no stage com JOIN em planoMidiaGrupo_dm_vw (nome, usuário, agência), 28 colunas em PT-BR, ordenado por roteiro → semana → GEO → exibidor
- api/relatorio-p1a.js: registra action 'empilhamento' no dispatcher
- vercel.json: adiciona rewrite /api/relatorio-p1a-empilhamento
- exportXlsx.ts: nova função exportP1aEmpilhado com cabeçalhos amigáveis, larguras ajustadas, freeze no cabeçalho e datas formatadas em pt-BR
- RelatorioP1A.tsx: botão "Exportar empilhado" (outline laranja) com spinner, ativo desde que haja roteiros selecionados (independente de carregar as abas)