### PR TITLE
feat(p1a): adiciona filtros Marca e Agência como seleção principal no…

### DIFF
--- a/handlers/relatorio-p1a-options.js
+++ b/handlers/relatorio-p1a-options.js
@@ -41,6 +41,7 @@ async function listReports(pool, empresaPk) {
       semanasMax_vl,
       date_dh,
       agencia_st,
+      marca_st,
       liberadoAgencia_bl
     FROM [serv_product_be180].[planoMidiaGrupo_dm_vw]
     WHERE delete_bl = 0 ${agenciaFilter}

--- a/src/screens/RelatorioP1A/RelatorioP1A.tsx
+++ b/src/screens/RelatorioP1A/RelatorioP1A.tsx
@@ -428,9 +428,6 @@ export const RelatorioP1A: React.FC = () => {
 
             {/* Seletor de roteiros */}
             <div className="mb-4">
-              <label className="block text-xs font-medium text-[#757575] uppercase tracking-wide mb-1">
-                Roteiros
-              </label>
               <P1aReportSelector
                 reports={optionsGlobal?.reports || []}
                 selected={filters.reportPks}

--- a/src/screens/RelatorioP1A/components/P1aFilters.tsx
+++ b/src/screens/RelatorioP1A/components/P1aFilters.tsx
@@ -27,7 +27,6 @@ export const P1aFiltersBar: React.FC<P1aFiltersProps> = ({
   disabled,
 }) => {
   const dimensionValues = options?.dimensions[filters.dimension] ?? [];
-  const marcas = options?.marcas ?? [];
 
   const update = (patch: Partial<P1aFilters>) => onChange({ ...filters, ...patch });
 
@@ -35,26 +34,7 @@ export const P1aFiltersBar: React.FC<P1aFiltersProps> = ({
     'h-[44px] px-3 rounded-lg border bg-white text-sm text-[#3a3a3a] focus:outline-none focus:ring-2 focus:ring-[#ff4600]/30 focus:border-[#ff4600] disabled:bg-[#f8f8f8] disabled:text-[#999]';
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-      <div className="flex flex-col gap-1">
-        <label className="text-xs font-medium text-[#757575] uppercase tracking-wide">
-          Marca
-        </label>
-        <select
-          className={`${baseSelectClass} border-[#d9d9d9]`}
-          value={filters.marca ?? ''}
-          onChange={(e) => update({ marca: e.target.value || null })}
-          disabled={disabled || marcas.length === 0}
-        >
-          <option value="">Todas</option>
-          {marcas.map((m) => (
-            <option key={m} value={m}>
-              {m}
-            </option>
-          ))}
-        </select>
-      </div>
-
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
       <div className="flex flex-col gap-1">
         <label className="text-xs font-medium text-[#757575] uppercase tracking-wide">
           Dimensão

--- a/src/screens/RelatorioP1A/components/P1aReportSelector.tsx
+++ b/src/screens/RelatorioP1A/components/P1aReportSelector.tsx
@@ -18,18 +18,36 @@ export const P1aReportSelector: React.FC<P1aReportSelectorProps> = ({
   const [aberto, setAberto] = useState(false);
   const [busca, setBusca] = useState('');
   const [filtroUsuario, setFiltroUsuario] = useState<string>('');
+  const [filtroMarca, setFiltroMarca] = useState<string>('');
+  const [filtroAgencia, setFiltroAgencia] = useState<string>('');
+
+  const marcas = useMemo(() => {
+    const set = new Set<string>();
+    reports.forEach((r) => { if (r.marca_st) set.add(r.marca_st); });
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+  }, [reports]);
+
+  // Agências disponíveis respeitam a marca selecionada
+  const agencias = useMemo(() => {
+    const set = new Set<string>();
+    reports.forEach((r) => {
+      if (filtroMarca && r.marca_st !== filtroMarca) return;
+      if (r.agencia_st) set.add(r.agencia_st);
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+  }, [reports, filtroMarca]);
 
   const usuarios = useMemo(() => {
     const set = new Set<string>();
-    reports.forEach((r) => {
-      if (r.usuarioName_st) set.add(r.usuarioName_st);
-    });
+    reports.forEach((r) => { if (r.usuarioName_st) set.add(r.usuarioName_st); });
     return Array.from(set).sort((a, b) => a.localeCompare(b, 'pt-BR'));
   }, [reports]);
 
   const filtrados = useMemo(() => {
     const termo = busca.trim().toLowerCase();
     return reports.filter((r) => {
+      if (filtroMarca && r.marca_st !== filtroMarca) return false;
+      if (filtroAgencia && r.agencia_st !== filtroAgencia) return false;
       if (filtroUsuario && r.usuarioName_st !== filtroUsuario) return false;
       if (!termo) return true;
       const haystack = [
@@ -45,7 +63,7 @@ export const P1aReportSelector: React.FC<P1aReportSelectorProps> = ({
         .toLowerCase();
       return haystack.includes(termo);
     });
-  }, [reports, busca, filtroUsuario]);
+  }, [reports, busca, filtroUsuario, filtroMarca, filtroAgencia]);
 
   const selectedSet = useMemo(() => new Set(selected), [selected]);
 
@@ -73,156 +91,204 @@ export const P1aReportSelector: React.FC<P1aReportSelectorProps> = ({
       : `${selected.length} roteiros selecionados`;
 
   return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={() => setAberto((v) => !v)}
-        className={`w-full flex items-center justify-between gap-2 h-[44px] px-4 rounded-lg border bg-white text-left transition-colors ${
-          aberto
-            ? 'border-[#ff4600] ring-2 ring-[#ff4600]/20'
-            : 'border-[#d9d9d9] hover:border-[#bbb]'
-        }`}
-      >
-        <span
-          className={`text-sm truncate ${
-            selected.length > 0 ? 'text-[#222]' : 'text-[#757575]'
-          }`}
-        >
-          {resumo}
-        </span>
-        <svg
-          className={`w-4 h-4 text-[#757575] transition-transform ${
-            aberto ? 'rotate-180' : ''
-          }`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
-      </button>
-
-      {aberto && (
-        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-[#d9d9d9] rounded-lg shadow-xl z-30 max-h-[520px] flex flex-col">
-          <div className="p-3 border-b border-[#ededed] flex flex-col gap-2">
-            <input
-              type="text"
-              value={busca}
-              onChange={(e) => setBusca(e.target.value)}
-              placeholder="Buscar por PK, nome, marca, agência, cidade..."
-              className="w-full h-[36px] px-3 rounded-md border border-[#d9d9d9] focus:outline-none focus:ring-2 focus:ring-[#ff4600]/30 focus:border-[#ff4600] text-sm"
-            />
-            <div className="flex items-center gap-2">
-              <select
-                value={filtroUsuario}
-                onChange={(e) => setFiltroUsuario(e.target.value)}
-                className="h-[32px] px-2 rounded-md border border-[#d9d9d9] text-sm text-[#3a3a3a] flex-1"
-              >
-                <option value="">Todos os usuários</option>
-                {usuarios.map((u) => (
-                  <option key={u} value={u}>
-                    {u}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={marcarVisiveis}
-                className="text-xs px-2 py-1 rounded border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a]"
-                disabled={filtrados.length === 0}
-              >
-                Marcar visíveis
-              </button>
-              <button
-                type="button"
-                onClick={limpar}
-                className="text-xs px-2 py-1 rounded border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a]"
-                disabled={selected.length === 0}
-              >
-                Limpar
-              </button>
-            </div>
-            <div className="text-xs text-[#757575]">
-              {filtrados.length} de {reports.length} roteiros · {selected.length} selecionados
-            </div>
-          </div>
-
-          <div className="overflow-auto flex-1">
-            {loading ? (
-              <div className="p-4 text-center text-sm text-[#757575]">Carregando roteiros…</div>
-            ) : filtrados.length === 0 ? (
-              <div className="p-4 text-center text-sm text-[#757575]">Nenhum roteiro encontrado.</div>
-            ) : (
-              <table className="w-full text-sm">
-                <thead className="sticky top-0 bg-[#f8f8f8] text-left text-xs uppercase tracking-wide text-[#757575]">
-                  <tr>
-                    <th className="px-3 py-2 w-[40px]"></th>
-                    <th className="px-2 py-2">PK</th>
-                    <th className="px-2 py-2">Nome</th>
-                    <th className="px-2 py-2">Usuário</th>
-                    <th className="px-2 py-2">Cidade(s)</th>
-                    <th className="px-2 py-2">Sem</th>
-                    <th className="px-2 py-2">Data</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtrados.map((r) => {
-                    const checked = selectedSet.has(r.planoMidiaGrupo_pk);
-                    return (
-                      <tr
-                        key={r.planoMidiaGrupo_pk}
-                        onClick={() => toggle(r.planoMidiaGrupo_pk)}
-                        className={`cursor-pointer border-t border-[#f0f0f0] hover:bg-[#fafafa] ${
-                          checked ? 'bg-[#fff5ef]' : ''
-                        }`}
-                      >
-                        <td className="px-3 py-2">
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={(e) => {
-                              e.stopPropagation();
-                              toggle(r.planoMidiaGrupo_pk);
-                            }}
-                            className="accent-[#ff4600]"
-                          />
-                        </td>
-                        <td className="px-2 py-2 font-mono text-xs text-[#3a3a3a]">
-                          {r.planoMidiaGrupo_pk}
-                        </td>
-                        <td className="px-2 py-2 text-[#222]">{r.planoMidiaGrupo_st}</td>
-                        <td className="px-2 py-2 text-[#3a3a3a]">{r.usuarioName_st || '—'}</td>
-                        <td className="px-2 py-2 text-[#3a3a3a] truncate max-w-[200px]">
-                          {r.cidadeUpper_st_concat || '—'}
-                        </td>
-                        <td className="px-2 py-2 text-[#3a3a3a]">{r.semanasMax_vl ?? '—'}</td>
-                        <td className="px-2 py-2 text-xs text-[#757575] whitespace-nowrap">
-                          {formatDateBr(r.date_dh)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
-          </div>
-
-          <div className="p-2 border-t border-[#ededed] flex justify-end">
-            <button
-              type="button"
-              onClick={() => setAberto(false)}
-              className="px-3 py-1.5 text-sm rounded-md bg-[#ff4600] text-white hover:bg-[#e63d00]"
-            >
-              Concluir
-            </button>
-          </div>
+    <div className="flex flex-col gap-3">
+      {/* ── Filtros principais: Marca e Agência ── */}
+      <div className="flex gap-3">
+        <div className="flex-1 flex flex-col gap-1">
+          <label className="text-xs font-semibold text-[#757575] uppercase tracking-wide">
+            Marca
+          </label>
+          <select
+            value={filtroMarca}
+            onChange={(e) => {
+              setFiltroMarca(e.target.value);
+              setFiltroAgencia(''); // limpa agência ao trocar marca
+            }}
+            className={`w-full h-[40px] px-3 rounded-lg border text-sm bg-white transition-colors ${
+              filtroMarca
+                ? 'border-[#ff4600] ring-2 ring-[#ff4600]/20 text-[#222] font-medium'
+                : 'border-[#d9d9d9] text-[#3a3a3a]'
+            }`}
+          >
+            <option value="">Todas as marcas</option>
+            {marcas.map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
         </div>
-      )}
+
+        <div className="flex-1 flex flex-col gap-1">
+          <label className="text-xs font-semibold text-[#757575] uppercase tracking-wide">
+            Agência
+          </label>
+          <select
+            value={filtroAgencia}
+            onChange={(e) => setFiltroAgencia(e.target.value)}
+            className={`w-full h-[40px] px-3 rounded-lg border text-sm bg-white transition-colors ${
+              filtroAgencia
+                ? 'border-[#ff4600] ring-2 ring-[#ff4600]/20 text-[#222] font-medium'
+                : 'border-[#d9d9d9] text-[#3a3a3a]'
+            }`}
+          >
+            <option value="">Todas as agências</option>
+            {agencias.map((a) => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* ── Seletor de roteiros (já pré-filtrado pela marca/agência) ── */}
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-semibold text-[#757575] uppercase tracking-wide">
+          Roteiros{' '}
+          {(filtroMarca || filtroAgencia) && (
+            <span className="normal-case font-normal text-[#ff4600]">
+              — {filtrados.length} disponíveis
+            </span>
+          )}
+        </label>
+
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setAberto((v) => !v)}
+            className={`w-full flex items-center justify-between gap-2 h-[44px] px-4 rounded-lg border bg-white text-left transition-colors ${
+              aberto
+                ? 'border-[#ff4600] ring-2 ring-[#ff4600]/20'
+                : 'border-[#d9d9d9] hover:border-[#bbb]'
+            }`}
+          >
+            <span className={`text-sm truncate ${selected.length > 0 ? 'text-[#222]' : 'text-[#757575]'}`}>
+              {resumo}
+            </span>
+            <svg
+              className={`w-4 h-4 text-[#757575] transition-transform flex-shrink-0 ${aberto ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {aberto && (
+            <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-[#d9d9d9] rounded-lg shadow-xl z-30 max-h-[520px] flex flex-col">
+              <div className="p-3 border-b border-[#ededed] flex flex-col gap-2">
+                <input
+                  type="text"
+                  value={busca}
+                  onChange={(e) => setBusca(e.target.value)}
+                  placeholder="Buscar por PK, nome, cidade..."
+                  className="w-full h-[36px] px-3 rounded-md border border-[#d9d9d9] focus:outline-none focus:ring-2 focus:ring-[#ff4600]/30 focus:border-[#ff4600] text-sm"
+                />
+                <div className="flex items-center gap-2">
+                  <select
+                    value={filtroUsuario}
+                    onChange={(e) => setFiltroUsuario(e.target.value)}
+                    className="h-[30px] px-2 rounded-md border border-[#d9d9d9] text-sm text-[#3a3a3a] flex-1"
+                  >
+                    <option value="">Todos os usuários</option>
+                    {usuarios.map((u) => (
+                      <option key={u} value={u}>{u}</option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={marcarVisiveis}
+                    className="text-xs px-2 py-1 rounded border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a] whitespace-nowrap"
+                    disabled={filtrados.length === 0}
+                  >
+                    Marcar visíveis
+                  </button>
+                  <button
+                    type="button"
+                    onClick={limpar}
+                    className="text-xs px-2 py-1 rounded border border-[#d9d9d9] hover:bg-[#f8f8f8] text-[#3a3a3a]"
+                    disabled={selected.length === 0}
+                  >
+                    Limpar
+                  </button>
+                </div>
+                <div className="text-xs text-[#757575]">
+                  {filtrados.length} de {reports.length} roteiros · {selected.length} selecionados
+                </div>
+              </div>
+
+              <div className="overflow-auto flex-1">
+                {loading ? (
+                  <div className="p-4 text-center text-sm text-[#757575]">Carregando roteiros…</div>
+                ) : filtrados.length === 0 ? (
+                  <div className="p-4 text-center text-sm text-[#757575]">Nenhum roteiro encontrado.</div>
+                ) : (
+                  <table className="w-full text-sm">
+                    <thead className="sticky top-0 bg-[#f8f8f8] text-left text-xs uppercase tracking-wide text-[#757575]">
+                      <tr>
+                        <th className="px-3 py-2 w-[40px]"></th>
+                        <th className="px-2 py-2">PK</th>
+                        <th className="px-2 py-2">Nome</th>
+                        <th className="px-2 py-2">Marca</th>
+                        <th className="px-2 py-2">Agência</th>
+                        <th className="px-2 py-2">Usuário</th>
+                        <th className="px-2 py-2">Cidade(s)</th>
+                        <th className="px-2 py-2">Sem</th>
+                        <th className="px-2 py-2">Data</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filtrados.map((r) => {
+                        const checked = selectedSet.has(r.planoMidiaGrupo_pk);
+                        return (
+                          <tr
+                            key={r.planoMidiaGrupo_pk}
+                            onClick={() => toggle(r.planoMidiaGrupo_pk)}
+                            className={`cursor-pointer border-t border-[#f0f0f0] hover:bg-[#fafafa] ${
+                              checked ? 'bg-[#fff5ef]' : ''
+                            }`}
+                          >
+                            <td className="px-3 py-2">
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={(e) => { e.stopPropagation(); toggle(r.planoMidiaGrupo_pk); }}
+                                className="accent-[#ff4600]"
+                              />
+                            </td>
+                            <td className="px-2 py-2 font-mono text-xs text-[#3a3a3a]">
+                              {r.planoMidiaGrupo_pk}
+                            </td>
+                            <td className="px-2 py-2 text-[#222]">{r.planoMidiaGrupo_st}</td>
+                            <td className="px-2 py-2 text-[#3a3a3a]">{r.marca_st || '—'}</td>
+                            <td className="px-2 py-2 text-[#3a3a3a]">{r.agencia_st || '—'}</td>
+                            <td className="px-2 py-2 text-[#3a3a3a]">{r.usuarioName_st || '—'}</td>
+                            <td className="px-2 py-2 text-[#3a3a3a] truncate max-w-[200px]">
+                              {r.cidadeUpper_st_concat || '—'}
+                            </td>
+                            <td className="px-2 py-2 text-[#3a3a3a]">{r.semanasMax_vl ?? '—'}</td>
+                            <td className="px-2 py-2 text-xs text-[#757575] whitespace-nowrap">
+                              {formatDateBr(r.date_dh)}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+
+              <div className="p-2 border-t border-[#ededed] flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => setAberto(false)}
+                  className="px-3 py-1.5 text-sm rounded-md bg-[#ff4600] text-white hover:bg-[#e63d00]"
+                >
+                  Concluir
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/screens/RelatorioP1A/types.ts
+++ b/src/screens/RelatorioP1A/types.ts
@@ -19,8 +19,8 @@ export interface ReportOption {
   semanasMax_vl: number | null;
   date_dh: string;
   agencia_st: string | null;
+  marca_st: string | null;
   liberadoAgencia_bl: number | null;
-  marca_st?: string | null;
 }
 
 export interface OptionsResponse {


### PR DESCRIPTION
… P1aReportSelector

- Marca e Agência aparecem como filtros guarda-chuva antes da lista de roteiros
- Ao selecionar Marca, a lista de Agências se adapta automaticamente
- Ao trocar Marca, Agência é limpa para evitar seleção inconsistente
- Roteiros já mostram quantos estão disponíveis com os filtros ativos
- Tabela de roteiros exibe colunas Marca e Agência
- Remove Marca do P1aFiltersBar (evita duplicidade visual)
- Backend: marca_st adicionada ao SELECT de listReports
- types.ts: marca_st agora é obrigatória (não-opcional)