### PR TITLE
fix(exibidores): corrige timeout no pré-preenchimento e melhora loading

### DIFF
--- a/handlers/exibidor-gestao.js
+++ b/handlers/exibidor-gestao.js
@@ -175,28 +175,75 @@ async function detalhePendente(req, res, pool) {
   const nome = String(req.query.nome_legado || '').trim();
   if (!nome) return res.status(400).json({ success: false, error: 'nome_legado é obrigatório' });
 
-  const ativos = await pool.request()
-    .input('nome', sql.NVarChar(255), nome)
-    .query(`
-      SELECT TOP 50 pk, code, cidade_st, estado_st, tipoMidia_st, environment_st, media_format_st
-      FROM [serv_product_be180].[bancoAtivosJoin_ft]
-      WHERE valid_bl = 1 AND UPPER(LTRIM(RTRIM(exibidor_st))) = UPPER(LTRIM(RTRIM(@nome)))
-      ORDER BY cidade_st, code
-    `);
+  const makeReq = () => pool.request().input('nome', sql.NVarChar(255), nome);
+  const filtro = `j.valid_bl = 1 AND UPPER(LTRIM(RTRIM(j.exibidor_st))) = UPPER(LTRIM(RTRIM(@nome)))`;
 
-  const total = await pool.request()
-    .input('nome', sql.NVarChar(255), nome)
-    .query(`
+  const [ativos, total, cidadeTop, empresa] = await Promise.all([
+    // Amostra de pontos
+    makeReq().query(`
+      SELECT TOP 50 j.pk, j.code, j.cidade_st, j.estado_st, j.tipoMidia_st, j.environment_st, j.media_format_st
+      FROM [serv_product_be180].[bancoAtivosJoin_ft] j
+      WHERE ${filtro}
+      ORDER BY j.cidade_st, j.code
+    `),
+    // Total de pontos
+    makeReq().query(`
       SELECT COUNT(1) AS total
-      FROM [serv_product_be180].[bancoAtivosJoin_ft]
-      WHERE valid_bl = 1 AND UPPER(LTRIM(RTRIM(exibidor_st))) = UPPER(LTRIM(RTRIM(@nome)))
-    `);
+      FROM [serv_product_be180].[bancoAtivosJoin_ft] j
+      WHERE ${filtro}
+    `),
+    // Cidade e UF com mais pontos (fallback)
+    makeReq().query(`
+      SELECT TOP 1 j.cidade_st, j.estado_st
+      FROM [serv_product_be180].[bancoAtivosJoin_ft] j
+      WHERE ${filtro}
+        AND j.cidade_st IS NOT NULL AND LTRIM(RTRIM(j.cidade_st)) <> ''
+        AND j.estado_st IS NOT NULL AND LTRIM(RTRIM(j.estado_st)) <> ''
+      GROUP BY j.cidade_st, j.estado_st
+      ORDER BY COUNT(1) DESC
+    `),
+    // Dados completos da empresa: direto em bancoAtivosExibidor_dm → bancoAtivosExibidorEmpresa_dm
+    // (sem tocar em bancoAtivosJoin_ft para evitar full scan na tabela fato)
+    makeReq().query(`
+      SELECT TOP 1
+        emp.empresa_st,
+        emp.cnpj_st,
+        emp.contatoNome_st,
+        emp.contatoEmail_st,
+        emp.contatoTelefone_st,
+        emp.cep_st,
+        emp.endereco_st,
+        emp.complemento_st,
+        emp.bairro_st
+      FROM [serv_product_be180].[bancoAtivosExibidor_dm] ex
+      JOIN [serv_product_be180].[bancoAtivosExibidorEmpresa_dm] emp
+        ON emp.media_exhibitor_id = ex.media_exhibitor_id
+      WHERE UPPER(LTRIM(RTRIM(ex.exibidor_st))) = UPPER(LTRIM(RTRIM(@nome)))
+      ORDER BY emp.pk
+    `),
+  ]);
+
+  const cidade1 = cidadeTop.recordset[0] || null;
+  const emp     = empresa.recordset[0]   || null;
 
   return res.status(200).json({
     success: true,
     nome_legado: nome,
     ativosLegado: ativos.recordset,
     totalAtivosLegado: total.recordset[0]?.total || 0,
+    // Dados de empresa para pré-preenchimento
+    empresa_st:         emp?.empresa_st         || null,
+    cnpj_st:            emp?.cnpj_st            || null,
+    contatoNome_st:     emp?.contatoNome_st     || null,
+    contatoEmail_st:    emp?.contatoEmail_st    || null,
+    contatoTelefone_st: emp?.contatoTelefone_st || null,
+    cep_st:             emp?.cep_st             || null,
+    endereco_st:        emp?.endereco_st        || null,
+    complemento_st:     emp?.complemento_st     || null,
+    bairro_st:          emp?.bairro_st          || null,
+    // Cidade/UF dos pontos (usados se empresa não tiver endereço)
+    cidadePrincipal_st: cidade1?.cidade_st || null,
+    estadoPrincipal_st: cidade1?.estado_st || null,
   });
 }
 

--- a/src/screens/GestaoExibidores/ModalCadastroExibidor.tsx
+++ b/src/screens/GestaoExibidores/ModalCadastroExibidor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import api from '../../config/axios';
 
 const UFS_BR = [
@@ -61,6 +61,37 @@ export const ModalCadastroExibidor: React.FC<Props> = ({ mode, onClose, onSucces
   const [buscandoCep, setBuscandoCep] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
   const [step, setStep] = useState<'dados' | 'dominios'>('dados');
+  const [carregandoLegado, setCarregandoLegado] = useState(false);
+  const [semDadosEmpresa, setSemDadosEmpresa] = useState(false);
+
+  // Ao abrir em modo do-legado, busca dados derivados dos pontos e pré-preenche
+  useEffect(() => {
+    if (mode.tipo !== 'do-legado') return;
+    setCarregandoLegado(true);
+    api
+      .get(`/referencia?action=exibidor-gestao&mode=detalhe-pendente&nome_legado=${encodeURIComponent(mode.nome_legado)}`)
+      .then(({ data }) => {
+        if (!data.success) return;
+        const temDados = !!(data.cnpj_st || data.contatoEmail_st || data.cep_st || data.cidadePrincipal_st);
+        setSemDadosEmpresa(!temDados);
+        setForm((f) => ({
+          ...f,
+          nome_fantasia_st: data.empresa_st         || f.nome_fantasia_st,
+          cnpj_st:          data.cnpj_st            || f.cnpj_st,
+          email_st:         data.contatoEmail_st    || f.email_st,
+          telefone_st:      data.contatoTelefone_st || f.telefone_st,
+          cep_st:           data.cep_st             || f.cep_st,
+          logradouro_st:    data.endereco_st        || f.logradouro_st,
+          complemento_st:   data.complemento_st     || f.complemento_st,
+          bairro_st:        data.bairro_st          || f.bairro_st,
+          cidade_st:        data.cidadePrincipal_st || f.cidade_st,
+          estado_st:        data.estadoPrincipal_st || f.estado_st,
+        }));
+      })
+      .catch(() => setSemDadosEmpresa(true))
+      .finally(() => setCarregandoLegado(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const setField = (k: keyof ReturnType<typeof emptyForm>, v: string) => {
     setForm((f) => ({ ...f, [k]: v }));
@@ -155,7 +186,7 @@ export const ModalCadastroExibidor: React.FC<Props> = ({ mode, onClose, onSucces
 
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4 overflow-y-auto">
-      <div className="bg-white rounded-2xl w-full max-w-3xl max-h-[90vh] flex flex-col">
+      <div className="relative bg-white rounded-2xl w-full max-w-3xl max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-start justify-between p-6 border-b border-[#eee]">
           <div>
@@ -192,6 +223,31 @@ export const ModalCadastroExibidor: React.FC<Props> = ({ mode, onClose, onSucces
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-6">
+          {/* Loading overlay — estilo Apple: spinner + texto discreto */}
+          {carregandoLegado && (
+            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-2xl bg-white/80 backdrop-blur-sm">
+              <svg
+                className="animate-spin"
+                width="28"
+                height="28"
+                viewBox="0 0 28 28"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle cx="14" cy="14" r="11" stroke="#e5e5e7" strokeWidth="2.5" />
+                <path
+                  d="M14 3 A11 11 0 0 1 25 14"
+                  stroke="#3a3a3c"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+              <p className="text-[13px] text-[#6e6e73] font-medium tracking-tight">
+                Buscando dados do banco de ativos…
+              </p>
+            </div>
+          )}
+
           {step === 'dados' ? (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="md:col-span-2">
@@ -241,7 +297,14 @@ export const ModalCadastroExibidor: React.FC<Props> = ({ mode, onClose, onSucces
               </div>
 
               <div className="md:col-span-2 border-t border-[#eee] pt-4 mt-2">
-                <p className="text-xs uppercase font-bold text-[#888] mb-3">Endereço (opcional)</p>
+                <p className="text-xs uppercase font-bold text-[#888] mb-1">
+                  Endereço (opcional)
+                </p>
+                {!carregandoLegado && semDadosEmpresa && mode.tipo === 'do-legado' && (
+                  <p className="text-xs text-[#999] mb-3">
+                    Não encontramos cadastro de empresa para este exibidor no banco de ativos. Preencha manualmente.
+                  </p>
+                )}
               </div>
               <div className="flex gap-2">
                 <div className="flex-1">


### PR DESCRIPTION
- Reescreve query de empresa do detalhePendente para ir direto em bancoAtivosExibidor_dm → bancoAtivosExibidorEmpresa_dm sem passar pela tabela fato bancoAtivosJoin_ft, eliminando timeout de 15s
- Substitui texto inline de loading por overlay com spinner SVG estilo Apple (backdrop-blur + arco fino girando + texto discreto em cinza)