### PR TITLE
feat(usuarios): coluna Acessou + rastreio de primeiro/último login

### DIFF
--- a/api/admin.js
+++ b/api/admin.js
@@ -1,6 +1,7 @@
 const handlers = {
   'usuarios': require('../handlers/usuarios'),
   'usuarios-permissoes': require('../handlers/usuarios-permissoes'),
+  'usuarios-registrar-acesso': require('../handlers/usuarios-registrar-acesso'),
   'perfis': require('../handlers/perfis'),
   'perfis-permissoes': require('../handlers/perfis-permissoes'),
   'areas': require('../handlers/areas'),

--- a/handlers/usuarios-registrar-acesso.js
+++ b/handlers/usuarios-registrar-acesso.js
@@ -1,0 +1,54 @@
+const { sql, getPool } = require('./db');
+
+/**
+ * Registra o acesso de um usuário ao sistema.
+ *
+ * POST /api/admin?action=usuarios-registrar-acesso
+ * Body: { email: string, auth0_sub?: string }
+ *
+ * - Sempre atualiza ultimoAcesso_dh = GETDATE()
+ * - Define primeiroAcesso_dh apenas na primeira vez (COALESCE)
+ * - Sincroniza auth0_id_st se ainda estiver NULL
+ *
+ * O endpoint é silencioso: nunca retorna 4xx que possa quebrar o fluxo de
+ * login. É chamado em fire-and-forget pelo AuthContext.
+ */
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Método não permitido' });
+  }
+
+  try {
+    const email = String(req.body?.email || '').trim().toLowerCase();
+    const auth0Sub = req.body?.auth0_sub ? String(req.body.auth0_sub).trim() : null;
+
+    if (!email || !email.includes('@')) {
+      return res.status(200).json({ success: false, reason: 'email_invalido' });
+    }
+
+    const pool = await getPool();
+
+    const result = await pool.request()
+      .input('email', sql.NVarChar(255), email)
+      .input('sub', sql.NVarChar(255), auth0Sub)
+      .query(`
+        UPDATE [serv_product_be180].[usuario_dm]
+        SET ultimoAcesso_dh    = SYSUTCDATETIME(),
+            primeiroAcesso_dh  = COALESCE(primeiroAcesso_dh, SYSUTCDATETIME()),
+            auth0_id_st        = COALESCE(auth0_id_st, @sub)
+        WHERE LOWER(email_st) = @email
+          AND ativo_bl = 1
+      `);
+
+    const rowsAffected = result.rowsAffected?.[0] || 0;
+
+    return res.status(200).json({
+      success: rowsAffected > 0,
+      rowsAffected,
+    });
+  } catch (error) {
+    console.error('[usuarios-registrar-acesso] erro:', error.message);
+    // Não propaga erro — não pode bloquear login
+    return res.status(200).json({ success: false, error: 'internal' });
+  }
+};

--- a/ongoing/13_MIGRATION_usuario_acesso.sql
+++ b/ongoing/13_MIGRATION_usuario_acesso.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Migração: rastreio de primeiro/último acesso de usuários
+-- Data: 2026-05-26
+-- ============================================================================
+-- Adiciona colunas em usuario_dm e recria a view usuario_completo_vw
+-- para expor primeiroAcesso_dh / ultimoAcesso_dh + dados do exibidor vinculado.
+-- ============================================================================
+
+USE [sql-be180-database-eastus];
+GO
+
+-- 1. Colunas em usuario_dm ---------------------------------------------------
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns c
+  JOIN sys.tables t ON t.object_id = c.object_id
+  JOIN sys.schemas s ON s.schema_id = t.schema_id
+  WHERE t.name = 'usuario_dm' AND s.name = 'serv_product_be180'
+    AND c.name = 'primeiroAcesso_dh'
+)
+BEGIN
+  ALTER TABLE [serv_product_be180].[usuario_dm]
+    ADD primeiroAcesso_dh datetime2(0) NULL;
+  PRINT '✅ Coluna primeiroAcesso_dh adicionada';
+END
+ELSE
+  PRINT 'ℹ️ primeiroAcesso_dh já existe';
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns c
+  JOIN sys.tables t ON t.object_id = c.object_id
+  JOIN sys.schemas s ON s.schema_id = t.schema_id
+  WHERE t.name = 'usuario_dm' AND s.name = 'serv_product_be180'
+    AND c.name = 'ultimoAcesso_dh'
+)
+BEGIN
+  ALTER TABLE [serv_product_be180].[usuario_dm]
+    ADD ultimoAcesso_dh datetime2(0) NULL;
+  PRINT '✅ Coluna ultimoAcesso_dh adicionada';
+END
+ELSE
+  PRINT 'ℹ️ ultimoAcesso_dh já existe';
+GO
+
+-- 2. View usuario_completo_vw ------------------------------------------------
+IF OBJECT_ID('[serv_product_be180].[usuario_completo_vw]', 'V') IS NOT NULL
+  DROP VIEW [serv_product_be180].[usuario_completo_vw];
+GO
+
+CREATE VIEW [serv_product_be180].[usuario_completo_vw]
+AS
+SELECT
+  u.pk                AS usuario_pk,
+  u.pk2               AS usuario_pk2,
+  u.nome_st           AS usuario_nome,
+  u.email_st          AS usuario_email,
+  u.telefone_st       AS usuario_telefone,
+  u.empresa_pk,
+  u.exibidor_fk,
+  u.auth0_id_st,
+  u.ativo_bl          AS usuario_ativo,
+  u.date_dh           AS usuario_data_criacao,
+  u.date_dt           AS usuario_data,
+  u.primeiroAcesso_dh,
+  u.ultimoAcesso_dh,
+  p.perfil_pk,
+  p.nome_st           AS perfil_nome,
+  p.descricao_st      AS perfil_descricao,
+  p.ativo_bl          AS perfil_ativo,
+  e.nome_st           AS exibidor_nome,
+  e.nome_fantasia_st  AS exibidor_nome_fantasia,
+  e.dominio_st        AS exibidor_dominio
+FROM [serv_product_be180].[usuario_dm] u
+LEFT JOIN [serv_product_be180].[perfil_dm]  p ON p.perfil_pk = u.perfil_pk
+LEFT JOIN [serv_product_be180].[exibidor_dm] e ON e.exibidor_pk = u.exibidor_fk;
+GO
+
+PRINT '✅ View usuario_completo_vw recriada com primeiroAcesso_dh / ultimoAcesso_dh';
+GO

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -56,6 +56,33 @@ interface CachedProfile {
 
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 min — revalida após meia hora
 
+// ── Marca o acesso no backend apenas uma vez por sessão (sessionStorage) ──
+//    Fire-and-forget: nunca bloqueia ou propaga erro para o fluxo de login.
+const ACESSO_REGISTRADO_KEY = 'colmeia_acesso_registrado_v1';
+
+function registrarAcessoUmaVez(email: string, auth0Sub: string) {
+  if (!email) return;
+  try {
+    const ja = sessionStorage.getItem(ACESSO_REGISTRADO_KEY);
+    if (ja === email.toLowerCase()) return;
+    sessionStorage.setItem(ACESSO_REGISTRADO_KEY, email.toLowerCase());
+  } catch { /* sessionStorage indisponível — segue sem caching */ }
+
+  axios
+    .post('/usuarios-registrar-acesso', {
+      email: email.toLowerCase(),
+      auth0_sub: auth0Sub || undefined,
+    })
+    .then((r) => {
+      // eslint-disable-next-line no-console
+      console.log('[acesso] registrado:', r.data);
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn('[acesso] falha (silencioso):', err?.response?.status, err?.response?.data);
+    });
+}
+
 function lerCache(sub: string): CachedProfile | null {
   try {
     const raw = sessionStorage.getItem(CACHE_PREFIX + sub);
@@ -135,6 +162,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           localUser.exibidor_fk = cached.exibidor_fk ?? null;
           setAcessoBloqueado(false);
           setUser({ ...localUser });
+          registrarAcessoUmaVez(email, sub);
         }
         setIsLoading(false);
         return; // cache válido — não bate na API
@@ -172,10 +200,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             });
             setAcessoBloqueado(false);
             setUser({ ...localUser });
+            registrarAcessoUmaVez(email, sub);
           } else if (isEmailInterno(email)) {
             gravarCache(sub, { bloqueado: false });
             setAcessoBloqueado(false);
             setUser({ ...localUser });
+            registrarAcessoUmaVez(email, sub);
           } else {
             // Email externo sem cadastro — tenta resolução por domínio
             try {
@@ -197,6 +227,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 });
                 setAcessoBloqueado(false);
                 setUser({ ...localUser });
+                registrarAcessoUmaVez(email, sub);
               } else {
                 gravarCache(sub, { bloqueado: true });
                 setAcessoBloqueado(true);
@@ -216,6 +247,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             gravarCache(sub, { bloqueado: false });
             setUser(localUser);
             setAcessoBloqueado(false);
+            registrarAcessoUmaVez(email, sub);
           } else {
             setAcessoBloqueado(true);
             setUser(null);
@@ -245,6 +277,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     localStorage.removeItem('auth_token');
     localStorage.removeItem('user_data');
     localStorage.removeItem('user_permissoes');
+    try { sessionStorage.removeItem(ACESSO_REGISTRADO_KEY); } catch { /* ok */ }
     // Limpa cache de perfil do usuário atual
     if (user?.id) limparCache(user.id);
     setUser(null);

--- a/src/screens/Admin/Usuarios/AdminUsuarios.tsx
+++ b/src/screens/Admin/Usuarios/AdminUsuarios.tsx
@@ -15,6 +15,8 @@ interface Usuario {
   perfil_descricao: string;
   empresa_pk: number | null;
   exibidor_fk: number | null;
+  primeiroAcesso_dh: string | null;
+  ultimoAcesso_dh: string | null;
 }
 
 interface Perfil {
@@ -52,6 +54,51 @@ const PerfilBadge: React.FC<{ nome: string }> = ({ nome }) => {
     >
       {nome}
     </span>
+  );
+};
+
+function formatarAcesso(dh: string | null): { label: string; relativo: string | null } {
+  if (!dh) return { label: 'Nunca acessou', relativo: null };
+  const d = new Date(dh);
+  if (Number.isNaN(d.getTime())) return { label: 'Nunca acessou', relativo: null };
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const yy = String(d.getFullYear()).slice(-2);
+  const label = `${dd}/${mm}/${yy}`;
+  const diffMs = Date.now() - d.getTime();
+  const diffDays = Math.floor(diffMs / 86_400_000);
+  let relativo: string;
+  if (diffDays <= 0) relativo = 'hoje';
+  else if (diffDays === 1) relativo = 'ontem';
+  else if (diffDays < 30) relativo = `há ${diffDays} dias`;
+  else if (diffDays < 365) relativo = `há ${Math.floor(diffDays / 30)} mês(es)`;
+  else relativo = `há ${Math.floor(diffDays / 365)} ano(s)`;
+  return { label, relativo };
+}
+
+const AcessoBadge: React.FC<{ dh: string | null }> = ({ dh }) => {
+  if (!dh) {
+    return (
+      <span
+        className="inline-block px-2.5 py-0.5 rounded-full text-[11px] font-semibold"
+        style={{ backgroundColor: '#fef3c7', color: '#92400e' }}
+        title="Este usuário ainda não fez login no sistema"
+      >
+        Nunca acessou
+      </span>
+    );
+  }
+  const { label, relativo } = formatarAcesso(dh);
+  return (
+    <div className="flex flex-col">
+      <span
+        className="inline-block w-fit px-2.5 py-0.5 rounded-full text-[11px] font-semibold"
+        style={{ backgroundColor: '#dcfce7', color: '#15803d' }}
+      >
+        ✓ {label}
+      </span>
+      {relativo && <span className="text-[10px] text-[#9ca3af] mt-0.5">{relativo}</span>}
+    </div>
   );
 };
 
@@ -214,6 +261,8 @@ export const AdminUsuarios: React.FC = () => {
     ativos:   usuarios.filter(u => u.usuario_ativo).length,
     inativos: usuarios.filter(u => !u.usuario_ativo).length,
     exibidores: usuarios.filter(u => u.perfil_nome?.toLowerCase().includes('exibidor')).length,
+    jaAcessaram: usuarios.filter(u => !!u.ultimoAcesso_dh).length,
+    nuncaAcessaram: usuarios.filter(u => !u.ultimoAcesso_dh).length,
   }), [usuarios]);
 
   return (
@@ -263,7 +312,7 @@ export const AdminUsuarios: React.FC = () => {
             </div>
 
             {/* Métricas */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
               <div className="rounded-xl border border-[#a8c2ef] bg-white p-4">
                 <p className="text-xs uppercase text-[#666] mb-1">Total</p>
                 <p className="text-2xl text-[#0a52e6] font-bold">{stats.total}</p>
@@ -279,6 +328,14 @@ export const AdminUsuarios: React.FC = () => {
               <div className="rounded-xl border border-[#f6c69b] bg-white p-4">
                 <p className="text-xs uppercase text-[#666] mb-1">Exibidores</p>
                 <p className="text-2xl text-[#ff4600] font-bold">{stats.exibidores}</p>
+              </div>
+              <div className="rounded-xl border border-[#bbf7d0] bg-white p-4">
+                <p className="text-xs uppercase text-[#666] mb-1">Já acessaram</p>
+                <p className="text-2xl text-[#15803d] font-bold">{stats.jaAcessaram}</p>
+              </div>
+              <div className="rounded-xl border border-[#fde68a] bg-white p-4">
+                <p className="text-xs uppercase text-[#666] mb-1">Nunca acessaram</p>
+                <p className="text-2xl text-[#92400e] font-bold">{stats.nuncaAcessaram}</p>
               </div>
             </div>
 
@@ -334,6 +391,7 @@ export const AdminUsuarios: React.FC = () => {
                       <th className="px-5 py-3 text-left text-[10px] font-semibold uppercase tracking-wider text-[#6b7280]">Perfil</th>
                       <th className="px-5 py-3 text-left text-[10px] font-semibold uppercase tracking-wider text-[#6b7280]">Vínculo</th>
                       <th className="px-5 py-3 text-left text-[10px] font-semibold uppercase tracking-wider text-[#6b7280]">Status</th>
+                      <th className="px-5 py-3 text-left text-[10px] font-semibold uppercase tracking-wider text-[#6b7280]">Último acesso</th>
                       <th className="px-5 py-3 text-right text-[10px] font-semibold uppercase tracking-wider text-[#6b7280]">Ações</th>
                     </tr>
                   </thead>
@@ -369,6 +427,9 @@ export const AdminUsuarios: React.FC = () => {
                           >
                             {usuario.usuario_ativo ? 'Ativo' : 'Inativo'}
                           </span>
+                        </td>
+                        <td className="px-5 py-3.5">
+                          <AcessoBadge dh={usuario.ultimoAcesso_dh} />
                         </td>
                         <td className="px-5 py-3.5 text-right">
                           {usuario.usuario_ativo ? (

--- a/vercel.json
+++ b/vercel.json
@@ -113,6 +113,8 @@
     { "source": "/perfis-permissoes", "destination": "/api/admin?action=perfis-permissoes" },
     { "source": "/api/usuarios", "destination": "/api/admin?action=usuarios" },
     { "source": "/api/usuarios-permissoes", "destination": "/api/admin?action=usuarios-permissoes" },
+    { "source": "/api/usuarios-registrar-acesso", "destination": "/api/admin?action=usuarios-registrar-acesso" },
+    { "source": "/usuarios-registrar-acesso", "destination": "/api/admin?action=usuarios-registrar-acesso" },
     { "source": "/api/perfis", "destination": "/api/admin?action=perfis" },
     { "source": "/api/perfis-permissoes", "destination": "/api/admin?action=perfis-permissoes" },
     { "source": "/api/areas", "destination": "/api/admin?action=areas" },


### PR DESCRIPTION
- Migração: adiciona primeiroAcesso_dh e ultimoAcesso_dh em usuario_dm
- View usuario_completo_vw recriada expondo as novas colunas + dados do exibidor vinculado
- Novo endpoint POST /api/usuarios-registrar-acesso (handler silencioso) que faz UPSERT: ultimoAcesso = agora, primeiroAcesso = COALESCE, auth0_id_st = COALESCE (sincroniza Auth0 sub no primeiro login)
- AuthContext dispara o endpoint em fire-and-forget em todos os caminhos de login bem-sucedido (cache hit, match por email, resolução por domínio, fallback interno Be); controlado por sessionStorage para bater 1x por sessão
- Tela Gerenciar Usuários: nova coluna "Último acesso" com badge verde (data + relativo) ou âmbar "Nunca acessou", + dois cards de métrica