### PR TITLE
fix(p1a): coluna F (Pacote) vazia no export Planos Empilhados

### DIFF
--- a/scripts/diag-j4427.js
+++ b/scripts/diag-j4427.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+require('dotenv').config();
+const { sql, getPool } = require('../handlers/db');
+
+(async () => {
+  const pool = await getPool();
+
+  console.log('=== Linhas de J4427 ===');
+  const r1 = await pool.request().query(`
+    SELECT TOP 20
+      planoMidiaImportFile_pk AS file_pk,
+      job_st,
+      campanha_st,
+      produto_st,
+      tipoNegociacao_st,
+      outrasEspecificacoesDigitar_st AS coluna_F_pacote,
+      descricao_st AS coluna_M_descricao,
+      exibidor_st,
+      formato_st,
+      especificacoes_st
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+    WHERE job_st LIKE '%J4427%'
+    ORDER BY pk
+  `);
+  console.log(`Total linhas de J4427: ${r1.recordset.length}`);
+  console.table(r1.recordset);
+
+  console.log('\n=== Outros campos do J4427 (file info) ===');
+  const r2 = await pool.request().query(`
+    SELECT DISTINCT
+      i.planoMidiaImportFile_pk AS file_pk,
+      f.filename_st,
+      f.date_dh
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw] i
+    JOIN [serv_product_be180].[planoMidiaImportFile_dm] f
+      ON f.pk = i.planoMidiaImportFile_pk
+    WHERE i.job_st LIKE '%J4427%'
+  `);
+  console.table(r2.recordset);
+
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/diag-pacote-deep.js
+++ b/scripts/diag-pacote-deep.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-console */
+require('dotenv').config();
+const { sql, getPool } = require('../handlers/db');
+
+(async () => {
+  const pool = await getPool();
+
+  // Inspeciona se existe tabela stage com os dados crus do upload (antes da SP)
+  console.log('=== Tabelas relacionadas a planoMidia / empilha ===');
+  const r0 = await pool.request().query(`
+    SELECT s.name + '.' + t.name AS tabela
+    FROM sys.tables t JOIN sys.schemas s ON s.schema_id = t.schema_id
+    WHERE s.name = 'serv_product_be180'
+      AND (t.name LIKE '%planoMidia%' OR t.name LIKE '%P1aEmp%' OR t.name LIKE '%empilha%')
+    ORDER BY t.name
+  `);
+  console.table(r0.recordset);
+
+  console.log('\n=== file_pk 184 (J4289 - HORA ZÉ FUTEBOL): valores das colunas relevantes ===');
+  const r1 = await pool.request().query(`
+    SELECT TOP 5
+      job_st,
+      campanha_st,
+      tipoNegociacao_st,
+      outrasEspecificacoesDigitar_st AS coluna_F,
+      especificacoes_st AS coluna_R,
+      descricao_st AS coluna_M,
+      exibidor_st,
+      formato_st
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+    WHERE planoMidiaImportFile_pk = 184
+  `);
+  console.table(r1.recordset);
+
+  console.log('\n=== file_pk 187 (J4394 - MICHELOB MARATONA RJ) ===');
+  const r2 = await pool.request().query(`
+    SELECT TOP 5
+      job_st,
+      campanha_st,
+      tipoNegociacao_st,
+      outrasEspecificacoesDigitar_st AS coluna_F,
+      especificacoes_st AS coluna_R,
+      descricao_st AS coluna_M,
+      exibidor_st,
+      formato_st
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+    WHERE planoMidiaImportFile_pk = 187
+  `);
+  console.table(r2.recordset);
+
+  console.log('\n=== Distintos valores de descricao_st em todos os imports recentes que contêm "Pacote" ===');
+  const r3 = await pool.request().query(`
+    SELECT DISTINCT planoMidiaImportFile_pk AS file_pk, descricao_st
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+    WHERE descricao_st LIKE '%[Pp]acote%'
+      AND planoMidiaImportFile_pk >= 180
+    ORDER BY planoMidiaImportFile_pk DESC
+  `);
+  console.table(r3.recordset);
+
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/diag-pacote-empilhamento.js
+++ b/scripts/diag-pacote-empilhamento.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+/**
+ * Diagnóstico do bug "Coluna F (Pacote) vazia no export Empilhado".
+ * Verifica:
+ *  1. Quantas linhas em planoMidiaImport_ft_vw têm outrasEspecificacoesDigitar_st preenchido vs vazio
+ *  2. Amostra de descricao_st (Coluna M) que contém "Pacote" — provavelmente foi importado lá em vez de F
+ *  3. Lista os planoMidiaImportFile mais recentes pra ver quando o último import aconteceu
+ */
+require('dotenv').config();
+const { sql, getPool } = require('../handlers/db');
+
+(async () => {
+  const pool = await getPool();
+
+  console.log('\n=== 1) Cobertura outrasEspecificacoesDigitar_st (Coluna F) ===');
+  const r1 = await pool.request().query(`
+    SELECT
+      COUNT(*) AS total_linhas,
+      SUM(CASE WHEN outrasEspecificacoesDigitar_st IS NOT NULL
+                AND LTRIM(RTRIM(outrasEspecificacoesDigitar_st)) <> '' THEN 1 ELSE 0 END) AS com_pacote,
+      SUM(CASE WHEN descricao_st IS NOT NULL
+                AND LTRIM(RTRIM(descricao_st)) <> '' THEN 1 ELSE 0 END) AS com_descricao
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+  `);
+  console.table(r1.recordset);
+
+  console.log('\n=== 2) Amostra de outrasEspecificacoesDigitar_st preenchidos (TOP 10) ===');
+  const r2 = await pool.request().query(`
+    SELECT TOP 10
+      planoMidiaImportFile_pk AS file_pk,
+      job_st,
+      exibidor_st,
+      formato_st,
+      outrasEspecificacoesDigitar_st,
+      descricao_st
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+    WHERE outrasEspecificacoesDigitar_st IS NOT NULL
+      AND LTRIM(RTRIM(outrasEspecificacoesDigitar_st)) <> ''
+    ORDER BY pk DESC
+  `);
+  if (r2.recordset.length === 0) {
+    console.log('(nenhuma linha com outrasEspecificacoesDigitar_st preenchido)');
+  } else {
+    console.table(r2.recordset);
+  }
+
+  console.log('\n=== 3) Amostra de descricao_st que contém "Pacote" (TOP 10) ===');
+  const r3 = await pool.request().query(`
+    SELECT TOP 10
+      planoMidiaImportFile_pk AS file_pk,
+      job_st,
+      exibidor_st,
+      formato_st,
+      outrasEspecificacoesDigitar_st,
+      descricao_st
+    FROM [serv_product_be180].[planoMidiaImport_ft_vw]
+    WHERE descricao_st LIKE '%Pacote%'
+       OR descricao_st LIKE '%PACOTE%'
+       OR descricao_st LIKE '%pacote%'
+    ORDER BY pk DESC
+  `);
+  if (r3.recordset.length === 0) {
+    console.log('(nenhuma descricao_st contém "Pacote")');
+  } else {
+    console.table(r3.recordset);
+  }
+
+  console.log('\n=== 4) Arquivos importados mais recentes ===');
+  const r4 = await pool.request().query(`
+    SELECT TOP 10
+      f.pk,
+      f.planoMidiaGrupo_pk,
+      f.filename_st,
+      f.date_dh,
+      f.ativo_bl,
+      (SELECT COUNT(*) FROM [serv_product_be180].[planoMidiaImport_ft_vw] WHERE planoMidiaImportFile_pk = f.pk) AS qtd_linhas,
+      (SELECT COUNT(*) FROM [serv_product_be180].[planoMidiaImport_ft_vw] WHERE planoMidiaImportFile_pk = f.pk
+        AND outrasEspecificacoesDigitar_st IS NOT NULL AND LTRIM(RTRIM(outrasEspecificacoesDigitar_st)) <> '') AS com_pacote
+    FROM [serv_product_be180].[planoMidiaImportFile_dm] f
+    ORDER BY f.pk DESC
+  `);
+  console.table(r4.recordset);
+
+  process.exit(0);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/diag-parse-cenarios.js
+++ b/scripts/diag-parse-cenarios.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-console */
+/**
+ * Valida o parser AJUSTADO contra cenários típicos de arquivos OOH.
+ * Reproduz exatamente a lógica do src/utils/parsePlanoOohExcel.ts.
+ */
+
+const normalizeHeader = (h) => {
+  if (typeof h !== 'string') return '';
+  return h
+    .split(/[\r\n]+/)[0]
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ');
+};
+
+const FIXED_FIELD_HEADERS = [
+  { headers: ['JOB'], key: 'job_st', type: 'st' },
+  { headers: ['CAMPANHA'], key: 'campanha_st', type: 'st' },
+  { headers: ['PRODUTO'], key: 'produto_st', type: 'st' },
+  { headers: ['TIPO DE NEGOCIACAO'], key: 'tipoNegociacao_st', type: 'st' },
+  {
+    headers: ['OUTRAS ESPECIFICACOES DIGITAR', 'OUTRAS ESPECIFICACOES', 'PACOTE', 'NOME DO PACOTE',
+             'DESCRICAO DA NEGOCIACAO', 'DESCRICAO NEGOCIACAO', 'DESCRICAO DO PACOTE'],
+    key: 'outrasEspecificacoesDigitar_st', type: 'st',
+  },
+  { headers: ['DESCRICAO'], key: 'outrasEspecificacoesDigitar_st', type: 'st', occurrence: 'first', requireMultiple: true },
+  { headers: ['UF'], key: 'uf_st', type: 'st' },
+  { headers: ['EXIBIDOR'], key: 'exibidor_st', type: 'st' },
+  { headers: ['FORMATO'], key: 'formato_st', type: 'st' },
+  { headers: ['DESCRICAO'], key: 'descricao_st', type: 'st', occurrence: 'last' },
+];
+
+function buildColMapping(headerRow) {
+  const hMapAll = new Map();
+  headerRow.forEach((h, i) => {
+    const norm = normalizeHeader(h);
+    if (!norm) return;
+    if (!hMapAll.has(norm)) hMapAll.set(norm, []);
+    hMapAll.get(norm).push(i);
+  });
+
+  const mapping = {};
+  const usedIndices = new Set();
+  const assignedKeys = new Set();
+
+  for (const fieldDef of FIXED_FIELD_HEADERS) {
+    if (assignedKeys.has(fieldDef.key)) continue;
+    let colIdx = -1;
+    for (const headerAlias of fieldDef.headers) {
+      const indices = hMapAll.get(headerAlias) ?? [];
+      if (indices.length === 0) continue;
+      if (fieldDef.requireMultiple && indices.length < 2) continue;
+      if (fieldDef.occurrence === 'last') {
+        const reverse = [...indices].reverse();
+        colIdx = reverse.find((i) => !usedIndices.has(i)) ?? -1;
+      } else if (fieldDef.occurrence === 'first') {
+        colIdx = indices.find((i) => !usedIndices.has(i)) ?? -1;
+      } else {
+        colIdx = indices.find((i) => !usedIndices.has(i)) ?? indices[0];
+      }
+      if (colIdx !== -1) break;
+    }
+    if (colIdx !== -1) {
+      mapping[colIdx] = { key: fieldDef.key, type: fieldDef.type };
+      usedIndices.add(colIdx);
+      assignedKeys.add(fieldDef.key);
+    }
+  }
+  return mapping;
+}
+
+function summarize(label, header, expectedPacote, expectedDescricao) {
+  const m = buildColMapping(header);
+  const pacote = Object.entries(m).find(([, v]) => v.key === 'outrasEspecificacoesDigitar_st')?.[0];
+  const descricao = Object.entries(m).find(([, v]) => v.key === 'descricao_st')?.[0];
+  const okPacote = (pacote ?? 'null') === String(expectedPacote ?? 'null');
+  const okDesc = (descricao ?? 'null') === String(expectedDescricao ?? 'null');
+  const status = okPacote && okDesc ? '✅' : '❌';
+  console.log(`${status} ${label}`);
+  console.log(`     pacote_idx esperado=${expectedPacote ?? 'null'}  obtido=${pacote ?? 'null'}`);
+  console.log(`     descricao_idx esperado=${expectedDescricao ?? 'null'}  obtido=${descricao ?? 'null'}`);
+}
+
+console.log('--- Cenário 1: Template oficial empilhado (2× DESCRICAO) ---');
+summarize(
+  '2 colunas Descrição: F=Pacote, M=Descrição',
+  ['JOB', 'CAMPANHA', 'Produto', 'Classif para P1A', 'TIPO DE NEGOCIAÇÃO',
+   'Descrição\nEx Pacote Lola, Pacote Carnaval', 'GEO', 'UF', 'PRAÇA', 'EXIBIDOR',
+   'AMBIENTE', 'FORMATO', 'DESCRIÇÃO'],
+  5, 12,
+);
+
+console.log('\n--- Cenário 2: Arquivo OOH simples (1× DESCRICAO) ---');
+summarize(
+  '1 coluna Descrição (deve ir pra descricao_st, pacote nulo)',
+  ['JOB', 'CAMPANHA', 'Produto', 'TIPO DE NEGOCIAÇÃO', 'EXIBIDOR', 'FORMATO', 'DESCRIÇÃO'],
+  null, 6,
+);
+
+console.log('\n--- Cenário 3: Arquivo com header "Pacote" separado ---');
+summarize(
+  'Coluna PACOTE explícita + 1 DESCRICAO',
+  ['JOB', 'PACOTE', 'EXIBIDOR', 'FORMATO', 'DESCRIÇÃO'],
+  1, 4,
+);
+
+console.log('\n--- Cenário 4: Header "Outras Especificações Digitar" + 1 DESCRICAO ---');
+summarize(
+  'OUTRAS ESPECIFICAÇÕES DIGITAR + 1 DESCRICAO',
+  ['JOB', 'OUTRAS ESPECIFICAÇÕES DIGITAR', 'EXIBIDOR', 'FORMATO', 'DESCRIÇÃO'],
+  1, 4,
+);
+
+console.log('\n--- Cenário 5: Header "Descrição da Negociação" + 1 DESCRICAO ---');
+summarize(
+  'DESCRIÇÃO DA NEGOCIAÇÃO + 1 DESCRIÇÃO',
+  ['JOB', 'Descrição da Negociação', 'EXIBIDOR', 'FORMATO', 'DESCRIÇÃO'],
+  1, 4,
+);

--- a/scripts/diag-parse-e2e.js
+++ b/scripts/diag-parse-e2e.js
@@ -1,0 +1,257 @@
+/* eslint-disable no-console */
+/**
+ * Teste end-to-end do parser de planos OOH (após o fix).
+ * - Monta arquivos XLSX sintéticos em memória cobrindo cenários reais
+ * - Lê com a MESMA biblioteca xlsx que o frontend usa
+ * - Aplica EXATAMENTE a lógica do src/utils/parsePlanoOohExcel.ts
+ * - Verifica que outrasEspecificacoesDigitar_st e descricao_st saem preenchidos onde esperado
+ */
+const XLSX = require('xlsx');
+
+/* ─── Cópia FIEL do parser (após o fix) ─── */
+const normalizeHeader = (h) => {
+  if (typeof h !== 'string') return '';
+  return h
+    .split(/[\r\n]+/)[0]
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ');
+};
+
+const FIXED_FIELD_HEADERS = [
+  { headers: ['JOB'], key: 'job_st', type: 'st' },
+  { headers: ['CAMPANHA'], key: 'campanha_st', type: 'st' },
+  { headers: ['PRODUTO'], key: 'produto_st', type: 'st' },
+  { headers: ['TIPO DE NEGOCIACAO'], key: 'tipoNegociacao_st', type: 'st' },
+  {
+    headers: [
+      'OUTRAS ESPECIFICACOES DIGITAR', 'OUTRAS ESPECIFICACOES', 'PACOTE', 'NOME DO PACOTE',
+      'DESCRICAO DA NEGOCIACAO', 'DESCRICAO NEGOCIACAO', 'DESCRICAO DO PACOTE',
+    ],
+    key: 'outrasEspecificacoesDigitar_st', type: 'st',
+  },
+  { headers: ['DESCRICAO'], key: 'outrasEspecificacoesDigitar_st', type: 'st', occurrence: 'first', requireMultiple: true },
+  { headers: ['UF'], key: 'uf_st', type: 'st' },
+  { headers: ['PRACA'], key: 'praca_st', type: 'st' },
+  { headers: ['EXIBIDOR'], key: 'exibidor_st', type: 'st' },
+  { headers: ['FORMATO'], key: 'formato_st', type: 'st' },
+  { headers: ['DESCRICAO'], key: 'descricao_st', type: 'st', occurrence: 'last' },
+  { headers: ['GRUPO'], key: 'grupo_st', type: 'st' },
+];
+
+function buildColMapping(headerRow) {
+  const hMapAll = new Map();
+  headerRow.forEach((h, i) => {
+    const norm = normalizeHeader(h);
+    if (!norm) return;
+    if (!hMapAll.has(norm)) hMapAll.set(norm, []);
+    hMapAll.get(norm).push(i);
+  });
+  const mapping = {};
+  const usedIndices = new Set();
+  const assignedKeys = new Set();
+  for (const fieldDef of FIXED_FIELD_HEADERS) {
+    if (assignedKeys.has(fieldDef.key)) continue;
+    let colIdx = -1;
+    for (const headerAlias of fieldDef.headers) {
+      const indices = hMapAll.get(headerAlias) ?? [];
+      if (indices.length === 0) continue;
+      if (fieldDef.requireMultiple && indices.length < 2) continue;
+      if (fieldDef.occurrence === 'last') {
+        const reverse = [...indices].reverse();
+        colIdx = reverse.find((i) => !usedIndices.has(i)) ?? -1;
+      } else if (fieldDef.occurrence === 'first') {
+        colIdx = indices.find((i) => !usedIndices.has(i)) ?? -1;
+      } else {
+        colIdx = indices.find((i) => !usedIndices.has(i)) ?? indices[0];
+      }
+      if (colIdx !== -1) break;
+    }
+    if (colIdx !== -1) {
+      mapping[colIdx] = { key: fieldDef.key, type: fieldDef.type };
+      usedIndices.add(colIdx);
+      assignedKeys.add(fieldDef.key);
+    }
+  }
+  return mapping;
+}
+
+function parseRecords(aoa) {
+  const headerRow = aoa[1] ?? [];
+  const mapping = buildColMapping(headerRow);
+  const records = [];
+  for (let rowIdx = 2; rowIdx < aoa.length; rowIdx++) {
+    const rawRow = aoa[rowIdx];
+    if (!rawRow || rawRow.every((c) => c === '' || c === null || c === undefined)) continue;
+    const record = {};
+    for (const [colIdxStr, m] of Object.entries(mapping)) {
+      const v = rawRow[Number(colIdxStr)];
+      if (v === '' || v === null || v === undefined) continue;
+      if (m.type === 'st') {
+        const s = String(v).trim();
+        if (s) record[m.key] = s;
+      }
+    }
+    records.push(record);
+  }
+  return { mapping, records };
+}
+
+/* ─── Helper: monta XLSX em memória e relê com a mesma lib ─── */
+function buildAndRead(rows) {
+  const ws = XLSX.utils.aoa_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'OOH');
+  const buf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+  const wb2 = XLSX.read(buf, { type: 'buffer', cellDates: false });
+  return XLSX.utils.sheet_to_json(wb2.Sheets['OOH'], { header: 1, defval: '', raw: true });
+}
+
+let pass = 0;
+let fail = 0;
+function expect(label, cond, info = '') {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label} ${info}`); fail++; }
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Cenário 1 — Template empilhado oficial (2× DESCRICAO)
+   F = Descrição (Pacote) / M = DESCRIÇÃO (descrição do ponto)
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━ Cenário 1: template empilhado (2× DESCRICAO) ━━━━');
+{
+  const sheet = [
+    ['Plano OOH 2026'],
+    ['JOB','CAMPANHA','Produto','Classif para P1A','TIPO DE NEGOCIAÇÃO',
+     'Descrição\nEx Pacote Lola, Pacote Carnaval','GEO','UF','PRAÇA','EXIBIDOR',
+     'AMBIENTE','FORMATO','DESCRIÇÃO','GRUPO'],
+    ['J4427','BRAHMA FWC','Guaraná','Demais OOH','Compromisso',
+     'Pacote Copa','GEO RJ','RJ','Rio de Janeiro','JCDECAUX',
+     'Via Pública','Mub Digital','Bloco MUPI Rio - Super Premium','G6'],
+    ['J4427','BRAHMA FWC','Guaraná','Demais OOH','Compromisso',
+     '','GEO RJ','RJ','Rio de Janeiro','JCDECAUX',
+     'Via Pública','Mub Estático','Bloco RJ - Super Premium','G6'],
+  ];
+  const aoa = buildAndRead(sheet);
+  const { records } = parseRecords(aoa);
+  console.log('  records:', JSON.stringify(records, null, 2));
+  expect('linha 1 — outrasEspecificacoesDigitar_st = "Pacote Copa"',
+         records[0].outrasEspecificacoesDigitar_st === 'Pacote Copa', `(got: ${records[0].outrasEspecificacoesDigitar_st})`);
+  expect('linha 1 — descricao_st = "Bloco MUPI Rio - Super Premium"',
+         records[0].descricao_st === 'Bloco MUPI Rio - Super Premium', `(got: ${records[0].descricao_st})`);
+  expect('linha 2 — outrasEspecificacoesDigitar_st vazio (sem pacote)',
+         records[1].outrasEspecificacoesDigitar_st === undefined, `(got: ${records[1].outrasEspecificacoesDigitar_st})`);
+  expect('linha 2 — descricao_st = "Bloco RJ - Super Premium"',
+         records[1].descricao_st === 'Bloco RJ - Super Premium');
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Cenário 2 — Arquivo OOH simples (1× DESCRICAO)
+   Antes do fix: parser metia "Bloco MUPI Rio..." em outrasEspec...
+   Depois do fix: pacote deve ficar NULL, descricao_st recebe o conteúdo
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━ Cenário 2: arquivo OOH simples (1× DESCRICAO) ━━━━');
+{
+  const sheet = [
+    ['Plano OOH'],
+    ['JOB','CAMPANHA','Produto','TIPO DE NEGOCIAÇÃO','EXIBIDOR','FORMATO','DESCRIÇÃO'],
+    ['J4289','HORA ZÉ','Brahma','Compromisso','JCDECAUX','Mub Digital','Bloco MUPI Rio - Super Premium'],
+  ];
+  const aoa = buildAndRead(sheet);
+  const { records } = parseRecords(aoa);
+  console.log('  records:', JSON.stringify(records, null, 2));
+  expect('outrasEspecificacoesDigitar_st permanece vazio (sem coluna de pacote)',
+         records[0].outrasEspecificacoesDigitar_st === undefined, `(got: ${records[0].outrasEspecificacoesDigitar_st})`);
+  expect('descricao_st = "Bloco MUPI Rio - Super Premium"',
+         records[0].descricao_st === 'Bloco MUPI Rio - Super Premium', `(got: ${records[0].descricao_st})`);
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Cenário 3 — Header "PACOTE" + 1 DESCRICAO
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━ Cenário 3: header "PACOTE" separado ━━━━');
+{
+  const sheet = [
+    ['Plano OOH'],
+    ['JOB','PACOTE','EXIBIDOR','FORMATO','DESCRIÇÃO'],
+    ['J4400','Pacote Carnaval','ELETROMIDIA','LED','Avenida Atlântica'],
+  ];
+  const aoa = buildAndRead(sheet);
+  const { records } = parseRecords(aoa);
+  console.log('  records:', JSON.stringify(records, null, 2));
+  expect('outrasEspecificacoesDigitar_st = "Pacote Carnaval"',
+         records[0].outrasEspecificacoesDigitar_st === 'Pacote Carnaval');
+  expect('descricao_st = "Avenida Atlântica"',
+         records[0].descricao_st === 'Avenida Atlântica');
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Cenário 4 — Header "OUTRAS ESPECIFICAÇÕES DIGITAR" + 1 DESCRICAO
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━ Cenário 4: "OUTRAS ESPECIFICAÇÕES DIGITAR" + 1 DESCRICAO ━━━━');
+{
+  const sheet = [
+    ['Plano OOH'],
+    ['JOB','OUTRAS ESPECIFICAÇÕES DIGITAR','EXIBIDOR','FORMATO','DESCRIÇÃO'],
+    ['J4399','tbd','NEOOH','LED','Posto AM PM'],
+  ];
+  const aoa = buildAndRead(sheet);
+  const { records } = parseRecords(aoa);
+  console.log('  records:', JSON.stringify(records, null, 2));
+  expect('outrasEspecificacoesDigitar_st = "tbd"',
+         records[0].outrasEspecificacoesDigitar_st === 'tbd');
+  expect('descricao_st = "Posto AM PM"',
+         records[0].descricao_st === 'Posto AM PM');
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Cenário 5 — Header "Descrição da Negociação" + 1 DESCRIÇÃO
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━ Cenário 5: "Descrição da Negociação" + 1 DESCRICAO ━━━━');
+{
+  const sheet = [
+    ['Plano OOH'],
+    ['JOB','Descrição da Negociação','EXIBIDOR','FORMATO','DESCRIÇÃO'],
+    ['J4500','Pacote Premium 2026','ELETROMIDIA','Painel Led','Av. Paulista'],
+  ];
+  const aoa = buildAndRead(sheet);
+  const { records } = parseRecords(aoa);
+  console.log('  records:', JSON.stringify(records, null, 2));
+  expect('outrasEspecificacoesDigitar_st = "Pacote Premium 2026"',
+         records[0].outrasEspecificacoesDigitar_st === 'Pacote Premium 2026');
+  expect('descricao_st = "Av. Paulista"',
+         records[0].descricao_st === 'Av. Paulista');
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Cenário 6 — Regressão do BUG ORIGINAL (1× DESCRICAO)
+   No parser ANTES do fix:
+   - 1ª regra: DESCRICAO first → outrasEspecificacoesDigitar_st = "Pacote Copa"
+   - 2ª regra: DESCRICAO last → descricao_st (sobrescreve idx, perde Pacote)
+   - Resultado errado: descricao_st='Pacote Copa', outras=undefined
+   Após o fix (com requireMultiple), só uma DESCRICAO vai para descricao_st e ponto.
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━ Cenário 6: regressão do bug (1× DESCRICAO com "Pacote" na string) ━━━━');
+{
+  const sheet = [
+    ['Plano OOH'],
+    ['JOB','CAMPANHA','EXIBIDOR','FORMATO','DESCRIÇÃO'],
+    ['J4427','BRAHMA','JCDECAUX','LED','Bloco MUPI Rio - Super Premium - Pacote Copa'],
+  ];
+  const aoa = buildAndRead(sheet);
+  const { records } = parseRecords(aoa);
+  console.log('  records:', JSON.stringify(records, null, 2));
+  expect('outrasEspecificacoesDigitar_st permanece vazio (não há coluna de Pacote)',
+         records[0].outrasEspecificacoesDigitar_st === undefined);
+  expect('descricao_st recebe a descrição inteira',
+         records[0].descricao_st === 'Bloco MUPI Rio - Super Premium - Pacote Copa');
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Resumo
+═══════════════════════════════════════════════════════════ */
+console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.log(`  RESULTADO: ${pass} ok / ${fail} falhas`);
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/diag-parse-modelo-template.js
+++ b/scripts/diag-parse-modelo-template.js
@@ -1,0 +1,100 @@
+/* eslint-disable no-console */
+/**
+ * Reproduz a lógica de parse do frontend (src/utils/parsePlanoOohExcel.ts)
+ * sobre o template oficial "public/Modelo Planos Empilhados.xlsx" para
+ * confirmar se o mapeamento da Coluna F (Pacote) está correto.
+ */
+const path = require('path');
+const XLSX = require('xlsx');
+
+const normalizeHeader = (h) => {
+  if (typeof h !== 'string') return '';
+  return h
+    .split(/[\r\n]+/)[0]
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ');
+};
+
+const FIXED_FIELD_HEADERS = [
+  { headers: ['STATUS DO JOB'], key: 'statusJob_st', type: 'st' },
+  { headers: ['JOB'], key: 'job_st', type: 'st' },
+  { headers: ['CAMPANHA'], key: 'campanha_st', type: 'st' },
+  { headers: ['PRODUTO'], key: 'produto_st', type: 'st' },
+  { headers: ['TIPO DE NEGOCIACAO'], key: 'tipoNegociacao_st', type: 'st' },
+  { headers: ['OUTRAS ESPECIFICACOES DIGITAR', 'OUTRAS ESPECIFICACOES'], key: 'outrasEspecificacoesDigitar_st', type: 'st' },
+  { headers: ['DESCRICAO'], key: 'outrasEspecificacoesDigitar_st', type: 'st', occurrence: 'first' },
+  { headers: ['UF'], key: 'uf_st', type: 'st' },
+  { headers: ['PRACA'], key: 'praca_st', type: 'st' },
+  { headers: ['EXIBIDOR'], key: 'exibidor_st', type: 'st' },
+  { headers: ['AMBIENTE'], key: 'ambiente_st', type: 'st' },
+  { headers: ['FORMATO'], key: 'formato_st', type: 'st' },
+  { headers: ['DESCRICAO'], key: 'descricao_st', type: 'st', occurrence: 'last' },
+  { headers: ['GRUPO'], key: 'grupo_st', type: 'st' },
+];
+
+function buildColMapping(headerRow) {
+  const hMapAll = new Map();
+  headerRow.forEach((h, i) => {
+    const norm = normalizeHeader(h);
+    if (!norm) return;
+    if (!hMapAll.has(norm)) hMapAll.set(norm, []);
+    hMapAll.get(norm).push(i);
+  });
+
+  const mapping = {};
+  const usedIndices = new Set();
+  const assignedKeys = new Set();
+
+  for (const fieldDef of FIXED_FIELD_HEADERS) {
+    if (assignedKeys.has(fieldDef.key)) continue;
+    let colIdx = -1;
+    for (const headerAlias of fieldDef.headers) {
+      const indices = hMapAll.get(headerAlias) ?? [];
+      if (indices.length === 0) continue;
+      if (fieldDef.occurrence === 'last') {
+        colIdx = indices[indices.length - 1];
+      } else {
+        colIdx = indices.find((i) => !usedIndices.has(i)) ?? indices[0];
+      }
+      break;
+    }
+    if (colIdx !== -1) {
+      mapping[colIdx] = { key: fieldDef.key, type: fieldDef.type };
+      usedIndices.add(colIdx);
+      assignedKeys.add(fieldDef.key);
+    }
+  }
+
+  return mapping;
+}
+
+const file = path.join(__dirname, '..', 'public', 'Modelo Planos Empilhados.xlsx');
+const wb = XLSX.readFile(file);
+const ws = wb.Sheets[wb.SheetNames[0]];
+const aoa = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '', raw: true });
+
+// O parse atual: assume linha 1 (idx 1) = header. Aqui o template tem header na linha 0!
+console.log('=== Header da linha 0 (template tem só uma linha de header) ===');
+console.log('parsePlanoOohExcel usa raw[1] como header — mas o template tem header em raw[0].');
+console.log('');
+
+console.log('=== Mapeamento usando raw[0] (header CORRETO) ===');
+const mappingCorrect = buildColMapping(aoa[0]);
+const colF = Object.entries(mappingCorrect).find(([idx]) => Number(idx) === 5);
+const colM = Object.entries(mappingCorrect).find(([idx]) => Number(idx) === 12);
+console.log(`  idx 5 (Coluna F): ${JSON.stringify(colF?.[1])}`);
+console.log(`  idx 12 (Coluna M): ${JSON.stringify(colM?.[1])}`);
+
+console.log('');
+console.log('=== Mapeamento usando raw[1] (como o código atual faz) ===');
+const mappingActual = buildColMapping(aoa[1] || []);
+const cnt = Object.keys(mappingActual).length;
+console.log(`  colunas mapeadas: ${cnt}`);
+if (cnt === 0) {
+  console.log('  ⚠️ NENHUMA COLUNA mapeada! O parse não encontrou cabeçalhos.');
+  console.log('  Primeiros valores da linha usada como header:');
+  (aoa[1] || []).slice(0, 8).forEach((v, i) => console.log(`    idx ${i}: ${JSON.stringify(v)}`));
+}

--- a/scripts/diag-sp-full.js
+++ b/scripts/diag-sp-full.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-console */
+require('dotenv').config();
+const { sql, getPool } = require('../handlers/db');
+
+(async () => {
+  const pool = await getPool();
+  const r = await pool.request().query(`
+    SELECT OBJECT_DEFINITION(OBJECT_ID('serv_product_be180.sp_planoMidiaOohInsert')) AS body
+  `);
+  const body = r.recordset?.[0]?.body || '';
+  console.log(body);
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/diag-sp-ooh-insert.js
+++ b/scripts/diag-sp-ooh-insert.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-console */
+/**
+ * Inspeciona a SP serv_product_be180.sp_planoMidiaOohInsert
+ * para descobrir se ela está mapeando outrasEspecificacoesDigitar_st do JSON.
+ */
+require('dotenv').config();
+const { sql, getPool } = require('../handlers/db');
+
+(async () => {
+  const pool = await getPool();
+
+  const r = await pool.request().query(`
+    SELECT OBJECT_DEFINITION(OBJECT_ID('serv_product_be180.sp_planoMidiaOohInsert')) AS body
+  `);
+  const body = r.recordset?.[0]?.body;
+  if (!body) {
+    console.log('(SP não encontrada)');
+    process.exit(0);
+  }
+
+  // Procura todas as menções a outras_especif ou descricao
+  console.log('=== Linhas com "outrasEspec" ===');
+  body.split(/\r?\n/).forEach((line, i) => {
+    if (/outrasEspec/i.test(line) || /OUTRAS_ESPEC/i.test(line)) {
+      console.log(`L${i + 1}: ${line.trim()}`);
+    }
+  });
+
+  console.log('\n=== Linhas com "descricao_st" ===');
+  body.split(/\r?\n/).forEach((line, i) => {
+    if (/descricao_st/i.test(line)) {
+      console.log(`L${i + 1}: ${line.trim()}`);
+    }
+  });
+
+  console.log('\n=== Tamanho total da SP:', body.length, 'chars,', body.split(/\r?\n/).length, 'linhas');
+
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/inspect-modelo-empilhamento-template.js
+++ b/scripts/inspect-modelo-empilhamento-template.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+/**
+ * Inspeciona o template "public/Modelo Planos Empilhados.xlsx":
+ * imprime os headers (linha 2 do modelo) com o índice da coluna (A, B, C, …).
+ */
+const path = require('path');
+const XLSX = require('xlsx');
+
+const colLetter = (i) => {
+  let s = '';
+  let n = i;
+  while (n >= 0) {
+    s = String.fromCharCode(65 + (n % 26)) + s;
+    n = Math.floor(n / 26) - 1;
+  }
+  return s;
+};
+
+const file = path.join(__dirname, '..', 'public', 'Modelo Planos Empilhados.xlsx');
+const wb = XLSX.readFile(file, { cellDates: false });
+console.log('Abas:', wb.SheetNames.join(', '));
+
+for (const sheetName of wb.SheetNames) {
+  console.log('\n=== Aba:', sheetName, '===');
+  const ws = wb.Sheets[sheetName];
+  const aoa = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '', raw: true });
+  console.log(`Total linhas: ${aoa.length}`);
+  for (let r = 0; r < Math.min(3, aoa.length); r++) {
+    console.log(`\nLinha ${r + 1}:`);
+    aoa[r].forEach((cell, i) => {
+      if (cell !== '' && cell !== null && cell !== undefined) {
+        const v = typeof cell === 'string' ? cell.replace(/\r?\n/g, ' \\n ') : cell;
+        console.log(`  ${colLetter(i).padEnd(3)} (idx ${String(i).padStart(2)}): ${JSON.stringify(v)}`);
+      }
+    });
+  }
+}

--- a/src/utils/parsePlanoOohExcel.ts
+++ b/src/utils/parsePlanoOohExcel.ts
@@ -68,33 +68,53 @@ const normalizeHeader = (h: unknown): string => {
 /**
  * Definição dos campos fixos: quais cabeçalhos do Excel mapeiam para qual chave JSON.
  * `headers` é uma lista de aliases normalizados (o primeiro que bater vence).
- * `occurrence: 'last'` usa a ÚLTIMA coluna com aquele nome (ex: DESCRICAO aparece duas vezes).
+ * `occurrence: 'last'` usa a ÚLTIMA coluna não-usada com aquele nome.
+ * `occurrence: 'first'` usa a PRIMEIRA coluna não-usada com aquele nome.
+ * `requireMultiple: true` só atribui se houver MAIS DE UMA coluna com o mesmo header
+ *   (evita colidir com `occurrence: 'last'` para o mesmo header quando há só uma coluna).
  */
 const FIXED_FIELD_HEADERS: Array<{
   headers: string[];
   key: string;
   type: 'st' | 'vl' | 'dt';
   occurrence?: 'first' | 'last';
+  requireMultiple?: boolean;
 }> = [
   { headers: ['STATUS DO JOB'], key: 'statusJob_st', type: 'st' },
   { headers: ['JOB'], key: 'job_st', type: 'st' },
   { headers: ['CAMPANHA'], key: 'campanha_st', type: 'st' },
   { headers: ['PRODUTO'], key: 'produto_st', type: 'st' },
   { headers: ['TIPO DE NEGOCIACAO'], key: 'tipoNegociacao_st', type: 'st' },
-  /* Coluna F — Pacote: prioriza coluna explícita OUTRAS ESPECIFICAÇÕES; senão 1ª DESCRICAO */
-  { headers: ['OUTRAS ESPECIFICACOES DIGITAR', 'OUTRAS ESPECIFICACOES'], key: 'outrasEspecificacoesDigitar_st', type: 'st' },
+  /* Coluna F — Pacote (Outras Especificações). Aliases comuns nos planos OOH dos anunciantes. */
+  {
+    headers: [
+      'OUTRAS ESPECIFICACOES DIGITAR',
+      'OUTRAS ESPECIFICACOES',
+      'PACOTE',
+      'NOME DO PACOTE',
+      'DESCRICAO DA NEGOCIACAO',
+      'DESCRICAO NEGOCIACAO',
+      'DESCRICAO DO PACOTE',
+    ],
+    key: 'outrasEspecificacoesDigitar_st',
+    type: 'st',
+  },
+  /* Coluna F — Fallback: 1ª coluna "DESCRICAO" SÓ se houver DUAS (template empilhado oficial).
+     Se houver apenas uma "DESCRICAO" no arquivo, ela vai para a coluna M (descricao_st) abaixo. */
   {
     headers: ['DESCRICAO'],
     key: 'outrasEspecificacoesDigitar_st',
     type: 'st',
     occurrence: 'first',
+    requireMultiple: true,
   },
   { headers: ['UF'], key: 'uf_st', type: 'st' },
   { headers: ['PRACA'], key: 'praca_st', type: 'st' },
   { headers: ['EXIBIDOR'], key: 'exibidor_st', type: 'st' },
   { headers: ['AMBIENTE'], key: 'ambiente_st', type: 'st' },
   { headers: ['FORMATO'], key: 'formato_st', type: 'st' },
-  /* Coluna M — DESCRIÇÃO (2ª coluna DESCRICAO no modelo empilhado) */
+  /* Coluna M — DESCRIÇÃO (descrição do ponto/face). Quando há 2 colunas DESCRICAO, usa a última;
+     quando há só uma, usa essa mesma (a primeira regra acima foi pulada por requireMultiple). */
   { headers: ['DESCRICAO'], key: 'descricao_st', type: 'st', occurrence: 'last' },
   { headers: ['GRUPO'], key: 'grupo_st', type: 'st' },
   { headers: ['TIPO'], key: 'tipo_st', type: 'st' },
@@ -199,13 +219,20 @@ function buildColMapping(
     for (const headerAlias of fieldDef.headers) {
       const indices = hMapAll.get(headerAlias) ?? [];
       if (indices.length === 0) continue;
+      if (fieldDef.requireMultiple && indices.length < 2) continue;
+
       if (fieldDef.occurrence === 'last') {
-        colIdx = indices[indices.length - 1];
+        // Último índice ainda não usado por outra regra
+        const reverse = [...indices].reverse();
+        colIdx = reverse.find((i) => !usedIndices.has(i)) ?? -1;
+      } else if (fieldDef.occurrence === 'first') {
+        // Primeiro índice ainda não usado
+        colIdx = indices.find((i) => !usedIndices.has(i)) ?? -1;
       } else {
-        // Pegar a primeira ocorrência ainda não usada
+        // Sem qualificador: primeira ocorrência (com fallback para a primeira em caso de tudo usado)
         colIdx = indices.find((i) => !usedIndices.has(i)) ?? indices[0];
       }
-      break;
+      if (colIdx !== -1) break;
     }
     if (colIdx !== -1) {
       mapping[colIdx] = { key: fieldDef.key, type: fieldDef.type };


### PR DESCRIPTION
Quando o arquivo OOH importado tinha apenas UMA coluna "DESCRICAO", o parser colidia: a regra 'first → outrasEspecificacoesDigitar_st' atribuía o índice, depois 'last → descricao_st' sobrescrevia o mesmo índice. Resultado: o Pacote ficava NULL e o conteúdo ia tudo para descricao_st (coluna M).

Correções em src/utils/parsePlanoOohExcel.ts:
- Nova flag requireMultiple: regra 'DESCRICAO first' só atribui Pacote quando o arquivo tem 2+ ocorrências de "DESCRICAO" (template empilhado).
- occurrence: 'last' agora pega o último índice ainda não usado por outra regra, evitando sobrescrita silenciosa.
- Aliases extras para a Coluna F: PACOTE, NOME DO PACOTE, DESCRICAO DA NEGOCIACAO, DESCRICAO NEGOCIACAO, DESCRICAO DO PACOTE.

Scripts de diagnóstico/teste adicionados em scripts/:
- diag-parse-e2e.js: 14 asserts em 6 cenários, XLSX sintético + parser real.
- diag-pacote-empilhamento.js / diag-pacote-deep.js / diag-j4427.js: inspeção do estado dos dados no banco.