### PR TITLE
feat(exibidores): grid full-width, ordenação clicável, edição de dado…

### DIFF
--- a/src/screens/GestaoExibidores/DrawerDetalheExibidor.tsx
+++ b/src/screens/GestaoExibidores/DrawerDetalheExibidor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import api from '../../config/axios';
 
 interface Props {
@@ -29,8 +29,42 @@ interface Detalhe {
 
 type Aba = 'dados' | 'dominios' | 'usuarios' | 'legado';
 
+/** Campos editáveis no formulário Dados (mesma lista que o backend aceita em op:'editar'). */
+const CAMPOS_EDITAVEIS = [
+  'nome_st',
+  'nome_fantasia_st',
+  'codigo_st',
+  'cnpj_st',
+  'site_st',
+  'email_st',
+  'telefone_st',
+  'cep_st',
+  'logradouro_st',
+  'numero_st',
+  'complemento_st',
+  'bairro_st',
+  'cidade_st',
+  'estado_st',
+  'observacao_st',
+  'active_bl',
+] as const;
+
+type CampoEditavel = (typeof CAMPOS_EDITAVEIS)[number];
+
+type FormDados = Partial<Record<CampoEditavel, string | number | boolean | null>>;
+
 function normalizarDominio(s: string) {
   return s.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+}
+
+function formatarCnpj(s: string): string {
+  const digits = String(s || '').replace(/\D/g, '').slice(0, 14);
+  if (digits.length <= 2) return digits;
+  if (digits.length <= 5) return `${digits.slice(0, 2)}.${digits.slice(2)}`;
+  if (digits.length <= 8) return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5)}`;
+  if (digits.length <= 12)
+    return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8)}`;
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
 }
 
 export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, onChanged }) => {
@@ -41,6 +75,10 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
   const [adicionando, setAdicionando] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
 
+  const [form, setForm] = useState<FormDados>({});
+  const [salvando, setSalvando] = useState(false);
+  const [sucesso, setSucesso] = useState<string | null>(null);
+
   const carregar = useCallback(async () => {
     setLoading(true);
     setErro(null);
@@ -49,6 +87,12 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
         `/referencia?action=exibidor-gestao&mode=detalhe&id=${exibidor_pk}`
       );
       setData(resp);
+      const e = resp?.exibidor || {};
+      const baseline: FormDados = {};
+      CAMPOS_EDITAVEIS.forEach((k) => {
+        baseline[k] = e[k] ?? (k === 'active_bl' ? 1 : '');
+      });
+      setForm(baseline);
     } catch (err: any) {
       setErro(err?.response?.data?.error || err?.message || 'Erro');
     } finally {
@@ -59,6 +103,62 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
   useEffect(() => {
     carregar();
   }, [carregar]);
+
+  const baselineExibidor = data?.exibidor;
+
+  const dirty = useMemo(() => {
+    if (!baselineExibidor) return false;
+    return CAMPOS_EDITAVEIS.some((k) => {
+      const orig = baselineExibidor[k] ?? (k === 'active_bl' ? 1 : '');
+      const atual = form[k] ?? (k === 'active_bl' ? 1 : '');
+      if (k === 'active_bl') return Boolean(Number(orig)) !== Boolean(Number(atual));
+      return String(orig ?? '') !== String(atual ?? '');
+    });
+  }, [form, baselineExibidor]);
+
+  const atualizarCampo = (k: CampoEditavel, v: string | boolean) => {
+    setForm((f) => ({ ...f, [k]: v as any }));
+    setSucesso(null);
+  };
+
+  const salvarDados = async () => {
+    setSalvando(true);
+    setErro(null);
+    setSucesso(null);
+    try {
+      const payload: Record<string, unknown> = { op: 'editar', exibidor_pk };
+      CAMPOS_EDITAVEIS.forEach((k) => {
+        let v = form[k];
+        if (k === 'cnpj_st' && typeof v === 'string') v = v.replace(/\D/g, '');
+        if (k === 'estado_st' && typeof v === 'string') v = v.toUpperCase().slice(0, 2);
+        if (k === 'active_bl') v = v ? 1 : 0;
+        payload[k] = v === '' ? null : v;
+      });
+      const { data: r } = await api.post('/referencia?action=exibidor-gestao', payload);
+      if (r?.success) {
+        setSucesso('Dados salvos com sucesso.');
+        await carregar();
+        onChanged();
+      } else {
+        setErro(r?.error || 'Erro ao salvar');
+      }
+    } catch (err: any) {
+      setErro(err?.response?.data?.error || err?.message || 'Erro');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const cancelarEdicao = () => {
+    if (!baselineExibidor) return;
+    const baseline: FormDados = {};
+    CAMPOS_EDITAVEIS.forEach((k) => {
+      baseline[k] = baselineExibidor[k] ?? (k === 'active_bl' ? 1 : '');
+    });
+    setForm(baseline);
+    setErro(null);
+    setSucesso(null);
+  };
 
   const adicionarDominio = async () => {
     const d = normalizarDominio(novoDominio);
@@ -138,7 +238,7 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
                 </span>
               )}
               {data.totalAtivosLegado > 0 ? (
-                <span className="px-2 py-0.5 rounded bg-[#eaf0fb] text-[#0a52e6] text-xs font-medium">
+                <span className="px-2 py-0.5 rounded bg-[#f3f4f6] text-[#374151] text-xs font-medium">
                   {data.totalAtivosLegado.toLocaleString('pt-BR')} ativos no legado
                 </span>
               ) : null}
@@ -174,24 +274,155 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-6">
           {aba === 'dados' ? (
-            <dl className="grid grid-cols-2 gap-4 text-sm">
-              <Linha label="ID" value={e.exibidor_pk} />
-              <Linha label="Código" value={e.codigo_st} />
-              <Linha label="CNPJ" value={e.cnpj_st} />
-              <Linha label="E-mail" value={e.email_st} />
-              <Linha label="Telefone" value={e.telefone_st} />
-              <Linha label="Site" value={e.site_st} />
-              <Linha label="CEP" value={e.cep_st} />
-              <Linha label="Estado" value={e.estado_st} />
-              <Linha label="Cidade" value={e.cidade_st} />
-              <Linha label="Bairro" value={e.bairro_st} />
-              <div className="col-span-2">
-                <Linha label="Endereço" value={[e.logradouro_st, e.numero_st, e.complemento_st].filter(Boolean).join(', ')} />
+            <div className="space-y-4">
+              <div className="text-xs text-[#6b7280]">
+                ID interno: <span className="font-mono text-[#222]">{e.exibidor_pk}</span>
               </div>
-              <div className="col-span-2">
-                <Linha label="Observação" value={e.observacao_st} />
+              <div className="grid grid-cols-2 gap-4">
+                <Campo label="Nome" required>
+                  <input
+                    type="text"
+                    value={String(form.nome_st ?? '')}
+                    onChange={(ev) => atualizarCampo('nome_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Nome fantasia">
+                  <input
+                    type="text"
+                    value={String(form.nome_fantasia_st ?? '')}
+                    onChange={(ev) => atualizarCampo('nome_fantasia_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Código">
+                  <input
+                    type="text"
+                    value={String(form.codigo_st ?? '')}
+                    onChange={(ev) => atualizarCampo('codigo_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="CNPJ">
+                  <input
+                    type="text"
+                    value={formatarCnpj(String(form.cnpj_st ?? ''))}
+                    onChange={(ev) => atualizarCampo('cnpj_st', ev.target.value)}
+                    placeholder="00.000.000/0000-00"
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="E-mail">
+                  <input
+                    type="email"
+                    value={String(form.email_st ?? '')}
+                    onChange={(ev) => atualizarCampo('email_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Telefone">
+                  <input
+                    type="text"
+                    value={String(form.telefone_st ?? '')}
+                    onChange={(ev) => atualizarCampo('telefone_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Site" full>
+                  <input
+                    type="text"
+                    value={String(form.site_st ?? '')}
+                    onChange={(ev) => atualizarCampo('site_st', ev.target.value)}
+                    placeholder="https://..."
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="CEP">
+                  <input
+                    type="text"
+                    value={String(form.cep_st ?? '')}
+                    onChange={(ev) => atualizarCampo('cep_st', ev.target.value)}
+                    placeholder="00000-000"
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Estado (UF)">
+                  <input
+                    type="text"
+                    value={String(form.estado_st ?? '')}
+                    onChange={(ev) => atualizarCampo('estado_st', ev.target.value.toUpperCase())}
+                    maxLength={2}
+                    placeholder="SP"
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Cidade" full>
+                  <input
+                    type="text"
+                    value={String(form.cidade_st ?? '')}
+                    onChange={(ev) => atualizarCampo('cidade_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Bairro">
+                  <input
+                    type="text"
+                    value={String(form.bairro_st ?? '')}
+                    onChange={(ev) => atualizarCampo('bairro_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Logradouro">
+                  <input
+                    type="text"
+                    value={String(form.logradouro_st ?? '')}
+                    onChange={(ev) => atualizarCampo('logradouro_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Número">
+                  <input
+                    type="text"
+                    value={String(form.numero_st ?? '')}
+                    onChange={(ev) => atualizarCampo('numero_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Complemento">
+                  <input
+                    type="text"
+                    value={String(form.complemento_st ?? '')}
+                    onChange={(ev) => atualizarCampo('complemento_st', ev.target.value)}
+                    className={inputCls}
+                  />
+                </Campo>
+                <Campo label="Observação" full>
+                  <textarea
+                    value={String(form.observacao_st ?? '')}
+                    onChange={(ev) => atualizarCampo('observacao_st', ev.target.value)}
+                    rows={3}
+                    className={`${inputCls} resize-y`}
+                  />
+                </Campo>
+                <Campo label="Status" full>
+                  <label className="inline-flex items-center gap-2 text-sm text-[#222]">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(Number(form.active_bl ?? 1))}
+                      onChange={(ev) => atualizarCampo('active_bl', ev.target.checked)}
+                      className="w-4 h-4 accent-[#ff4600]"
+                    />
+                    Exibidor ativo
+                  </label>
+                </Campo>
               </div>
-            </dl>
+
+              {sucesso ? (
+                <div className="p-3 rounded-lg bg-[#e7f3ea] border border-[#bce0c5] text-sm text-[#1f6b2c]">
+                  {sucesso}
+                </div>
+              ) : null}
+            </div>
           ) : null}
 
           {aba === 'dominios' ? (
@@ -212,7 +443,7 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
                 <button
                   onClick={adicionarDominio}
                   disabled={adicionando}
-                  className="h-[42px] px-4 bg-[#0a52e6] hover:bg-[#0843b8] text-white rounded-lg font-medium text-sm disabled:opacity-50"
+                  className="h-[42px] px-4 bg-[#111827] hover:bg-[#000] text-white rounded-lg font-medium text-sm disabled:opacity-50"
                 >
                   {adicionando ? '...' : '+ Adicionar'}
                 </button>
@@ -232,7 +463,7 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
                       <div className="flex items-center gap-2">
                         <span className="font-mono text-sm">{d.dominio_st}</span>
                         {d.primario_bl ? (
-                          <span className="px-1.5 py-0.5 rounded bg-[#0a52e6] text-white text-[10px] font-bold uppercase">
+                          <span className="px-1.5 py-0.5 rounded bg-[#111827] text-white text-[10px] font-bold uppercase">
                             primário
                           </span>
                         ) : null}
@@ -331,14 +562,45 @@ export const DrawerDetalheExibidor: React.FC<Props> = ({ exibidor_pk, onClose, o
             </div>
           ) : null}
         </div>
+
+        {/* Footer com ação de salvar (somente aba Dados) */}
+        {aba === 'dados' ? (
+          <div className="flex items-center justify-end gap-2 border-t border-[#eee] px-6 py-3 bg-[#fafafa]">
+            <button
+              onClick={cancelarEdicao}
+              disabled={!dirty || salvando}
+              className="h-[36px] px-4 text-sm rounded-lg border border-[#d9d9d9] bg-white text-[#3a3a3a] hover:bg-[#f3f4f6] disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={salvarDados}
+              disabled={!dirty || salvando}
+              className="h-[36px] px-4 text-sm font-medium rounded-lg bg-[#ff4600] hover:bg-[#e33d00] text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {salvando ? 'Salvando…' : 'Salvar alterações'}
+            </button>
+          </div>
+        ) : null}
       </div>
     </div>
   );
 };
 
-const Linha: React.FC<{ label: string; value: any }> = ({ label, value }) => (
-  <div>
-    <dt className="text-xs uppercase text-[#888] font-semibold tracking-wide">{label}</dt>
-    <dd className="text-sm text-[#222] mt-0.5">{value || <span className="text-[#bbb]">—</span>}</dd>
+const inputCls =
+  'w-full h-[38px] px-3 text-sm border border-[#d9d9d9] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#ff4600] focus:border-transparent';
+
+const Campo: React.FC<{ label: string; required?: boolean; full?: boolean; children: React.ReactNode }> = ({
+  label,
+  required,
+  full,
+  children,
+}) => (
+  <div className={full ? 'col-span-2' : ''}>
+    <label className="block text-[11px] uppercase text-[#888] font-semibold tracking-wide mb-1">
+      {label}
+      {required ? <span className="text-[#ff4600] ml-0.5">*</span> : null}
+    </label>
+    {children}
   </div>
 );

--- a/src/screens/GestaoExibidores/GestaoExibidores.tsx
+++ b/src/screens/GestaoExibidores/GestaoExibidores.tsx
@@ -24,6 +24,60 @@ export interface ExibidorListItem {
 
 type FiltroOrigem = 'TODOS' | 'CADASTRADO' | 'PENDENTE';
 
+type SortKey =
+  | 'origem_st'
+  | 'nome_st'
+  | 'qtd_dominios'
+  | 'qtd_usuarios'
+  | 'qtd_ativos_linkados';
+type SortDir = 'asc' | 'desc';
+
+/* Cadastrado vem antes de Pendente na ordenação por status. */
+const ORDEM_STATUS: Record<'CADASTRADO' | 'PENDENTE', number> = {
+  CADASTRADO: 0,
+  PENDENTE: 1,
+};
+
+interface SortableThProps {
+  col: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+  align?: 'left' | 'right';
+  children: React.ReactNode;
+}
+
+const SortableTh: React.FC<SortableThProps> = ({ col, current, dir, onSort, align = 'left', children }) => {
+  const active = current === col;
+  const arrow = !active ? '↕' : dir === 'asc' ? '↑' : '↓';
+  return (
+    <th
+      onClick={() => onSort(col)}
+      className={`px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-[#6b7280] cursor-pointer select-none hover:bg-[#f3f4f6] ${
+        align === 'right' ? 'text-right' : 'text-left'
+      }`}
+    >
+      <span className="inline-flex items-center gap-1">
+        {children}
+        <span className={`text-[9px] ${active ? 'text-[#ff4600]' : 'text-[#d1d5db]'}`}>{arrow}</span>
+      </span>
+    </th>
+  );
+};
+
+const MetricaInline: React.FC<{ label: string; value: React.ReactNode; cor?: string }> = ({
+  label,
+  value,
+  cor = '#222',
+}) => (
+  <div className="flex items-baseline gap-1.5">
+    <span className="text-[10px] uppercase tracking-wider text-[#9ca3af] font-semibold">{label}</span>
+    <span className="text-sm font-bold" style={{ color: cor }}>
+      {value}
+    </span>
+  </div>
+);
+
 export const GestaoExibidores: React.FC = () => {
   const [menuReduzido, setMenuReduzido] = useState(false);
   const [items, setItems] = useState<ExibidorListItem[]>([]);
@@ -32,6 +86,9 @@ export const GestaoExibidores: React.FC = () => {
   const [filtroOrigem, setFiltroOrigem] = useState<FiltroOrigem>('TODOS');
   const [incluirSandbox, setIncluirSandbox] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
+
+  const [sortKey, setSortKey] = useState<SortKey>('origem_st');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
 
   const [modalAberto, setModalAberto] = useState<
     | { tipo: 'novo' }
@@ -62,10 +119,53 @@ export const GestaoExibidores: React.FC = () => {
     carregar();
   }, [carregar]);
 
+  const handleSort = (col: SortKey) => {
+    if (sortKey === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(col);
+      setSortDir('asc');
+    }
+  };
+
   const itensFiltrados = useMemo(() => {
     if (filtroOrigem === 'TODOS') return items;
     return items.filter((i) => i.origem_st === filtroOrigem);
   }, [items, filtroOrigem]);
+
+  const itensOrdenados = useMemo(() => {
+    const arr = [...itensFiltrados];
+    const sign = sortDir === 'asc' ? 1 : -1;
+    arr.sort((a, b) => {
+      let va: number | string = '';
+      let vb: number | string = '';
+      switch (sortKey) {
+        case 'origem_st':
+          va = ORDEM_STATUS[a.origem_st];
+          vb = ORDEM_STATUS[b.origem_st];
+          if (va === vb) return a.nome_st.localeCompare(b.nome_st, 'pt-BR');
+          break;
+        case 'nome_st':
+          return sign * a.nome_st.localeCompare(b.nome_st, 'pt-BR');
+        case 'qtd_dominios':
+          va = Number(a.qtd_dominios || 0);
+          vb = Number(b.qtd_dominios || 0);
+          break;
+        case 'qtd_usuarios':
+          va = Number(a.qtd_usuarios || 0);
+          vb = Number(b.qtd_usuarios || 0);
+          break;
+        case 'qtd_ativos_linkados':
+          va = Number(a.qtd_ativos_linkados || 0);
+          vb = Number(b.qtd_ativos_linkados || 0);
+          break;
+      }
+      if (va < vb) return -1 * sign;
+      if (va > vb) return 1 * sign;
+      return a.nome_st.localeCompare(b.nome_st, 'pt-BR');
+    });
+    return arr;
+  }, [itensFiltrados, sortKey, sortDir]);
 
   const stats = useMemo(() => {
     const cadastrados = items.filter((i) => i.origem_st === 'CADASTRADO').length;
@@ -109,210 +209,237 @@ export const GestaoExibidores: React.FC = () => {
           }`}
         />
 
-        <div className="flex-1 pt-24 pb-16 px-8 overflow-auto">
-          <div className="max-w-7xl mx-auto">
-            {/* Cabeçalho */}
-            <div className="flex items-start justify-between mb-6 flex-wrap gap-4">
-              <div>
-                <h1 className="text-3xl font-bold text-[#ff4600] mb-2 uppercase tracking-wide">
-                  Gestão de exibidores
-                </h1>
-                <p className="text-[#3a3a3a] text-base leading-relaxed max-w-2xl">
-                  Cadastre exibidores existentes no banco de ativos legado, complete os dados e
-                  vincule domínios para liberar acesso à plataforma.
-                </p>
-              </div>
-              <button
-                onClick={() => setModalAberto({ tipo: 'novo' })}
-                className="bg-[#ff4600] hover:bg-[#e33d00] text-white font-medium h-[44px] px-6 rounded-lg transition-colors"
-              >
-                + Adicionar exibidor novo
-              </button>
+        <div className="flex-1 pt-20 pb-16 overflow-auto">
+          {/* Cabeçalho compacto */}
+          <div className="flex items-center justify-between gap-3 px-6 py-3 border-b border-[#f3f4f6]">
+            <div className="flex items-baseline gap-3">
+              <h1 className="text-base font-bold text-[#222]">Gestão de exibidores</h1>
+              <span className="text-xs text-[#9ca3af]">
+                {loading ? 'carregando…' : `${itensOrdenados.length} de ${items.length}`}
+              </span>
             </div>
-
-            {/* Métricas */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mb-6">
-              <div className="rounded-xl border border-[#a8c2ef] bg-white p-4">
-                <p className="text-xs uppercase text-[#666]">Cadastrados</p>
-                <p className="text-2xl text-[#0a52e6] font-bold">{stats.cadastrados}</p>
-              </div>
-              <div className="rounded-xl border border-[#f6c69b] bg-white p-4">
-                <p className="text-xs uppercase text-[#666]">Pendentes (no legado)</p>
-                <p className="text-2xl text-[#ff4600] font-bold">{stats.pendentes}</p>
-              </div>
-              <div className="rounded-xl border border-[#a8c2ef] bg-white p-4">
-                <p className="text-xs uppercase text-[#666]">Ativos linkados</p>
-                <p className="text-2xl text-[#0a52e6] font-bold">
-                  {stats.totalAtivosLinkados.toLocaleString('pt-BR')}
-                </p>
-              </div>
-              <div className="rounded-xl border border-[#f6c69b] bg-white p-4">
-                <p className="text-xs uppercase text-[#666]">Ativos sem dono</p>
-                <p className="text-2xl text-[#ff4600] font-bold">
-                  {stats.totalAtivosPendentes.toLocaleString('pt-BR')}
-                </p>
-              </div>
-            </div>
-
-            {/* Filtros */}
-            <div className="flex items-center gap-3 mb-4 flex-wrap">
-              <input
-                type="text"
-                placeholder="Buscar por nome..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && carregar()}
-                className="h-[40px] px-3 border border-[#d9d9d9] rounded-lg w-[300px] focus:outline-none focus:ring-2 focus:ring-[#ff4600]"
-              />
-              <button
-                onClick={carregar}
-                className="h-[40px] px-4 border border-[#d9d9d9] rounded-lg hover:bg-[#f8f8f8] text-sm"
-              >
-                Buscar
-              </button>
-
-              <div className="flex border border-[#d9d9d9] rounded-lg overflow-hidden">
-                {(['TODOS', 'CADASTRADO', 'PENDENTE'] as FiltroOrigem[]).map((f) => (
-                  <button
-                    key={f}
-                    onClick={() => setFiltroOrigem(f)}
-                    className={`h-[40px] px-4 text-sm font-medium ${
-                      filtroOrigem === f
-                        ? 'bg-[#ff4600] text-white'
-                        : 'bg-white text-[#3a3a3a] hover:bg-[#f8f8f8]'
-                    }`}
-                  >
-                    {f === 'TODOS' ? 'Todos' : f === 'CADASTRADO' ? 'Cadastrados' : 'Pendentes'}
-                  </button>
-                ))}
-              </div>
-
-              <label className="flex items-center gap-2 text-sm text-[#3a3a3a] ml-auto">
-                <input
-                  type="checkbox"
-                  checked={incluirSandbox}
-                  onChange={(e) => setIncluirSandbox(e.target.checked)}
-                  className="w-4 h-4 accent-[#ff4600]"
-                />
-                Mostrar sandbox
-              </label>
-            </div>
-
-            {/* Tabela */}
-            <div className="border border-[#ddd] rounded-xl overflow-hidden bg-white">
-              <table className="min-w-full text-sm">
-                <thead className="bg-[#f7f7f7] text-[#3a3a3a]">
-                  <tr>
-                    <th className="text-left px-4 py-3 font-semibold">Exibidor</th>
-                    <th className="text-left px-4 py-3 font-semibold">Status</th>
-                    <th className="text-right px-4 py-3 font-semibold">Domínios</th>
-                    <th className="text-right px-4 py-3 font-semibold">Usuários</th>
-                    <th className="text-right px-4 py-3 font-semibold">Ativos legado</th>
-                    <th className="text-right px-4 py-3 font-semibold w-[200px]">Ações</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {loading ? (
-                    <tr>
-                      <td colSpan={6} className="px-4 py-12 text-center text-[#666]">
-                        Carregando exibidores...
-                      </td>
-                    </tr>
-                  ) : itensFiltrados.length === 0 ? (
-                    <tr>
-                      <td colSpan={6} className="px-4 py-12 text-center text-[#666]">
-                        Nenhum exibidor encontrado.
-                      </td>
-                    </tr>
-                  ) : (
-                    itensFiltrados.map((item) => (
-                      <tr
-                        key={`${item.origem_st}-${item.exibidor_pk ?? item.nome_st}`}
-                        className="border-t border-[#eee] hover:bg-[#fafafa]"
-                      >
-                        <td className="px-4 py-3">
-                          <div className="font-medium text-[#222]">{item.nome_st}</div>
-                          {item.nome_fantasia_st && item.nome_fantasia_st !== item.nome_st ? (
-                            <div className="text-xs text-[#666]">{item.nome_fantasia_st}</div>
-                          ) : null}
-                          {item.cidade_st ? (
-                            <div className="text-xs text-[#888]">
-                              {item.cidade_st}
-                              {item.estado_st ? `/${item.estado_st}` : ''}
-                            </div>
-                          ) : null}
-                        </td>
-                        <td className="px-4 py-3">
-                          {item.origem_st === 'CADASTRADO' ? (
-                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#e7f3ea] text-[#1f6b2c] text-xs font-medium">
-                              ✓ Cadastrado
-                              {item.sandbox_bl ? (
-                                <span className="ml-1 px-1.5 py-0.5 rounded bg-[#fff5d4] text-[#7a5b00] text-[10px]">
-                                  sandbox
-                                </span>
-                              ) : null}
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#fff0e6] text-[#a8410d] text-xs font-medium">
-                              ⚠ Pendente
-                            </span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          {item.origem_st === 'CADASTRADO' ? (
-                            <span className={item.qtd_dominios === 0 ? 'text-[#a8410d]' : 'text-[#222]'}>
-                              {item.qtd_dominios}
-                            </span>
-                          ) : (
-                            <span className="text-[#aaa]">—</span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          {item.origem_st === 'CADASTRADO' ? (
-                            item.qtd_usuarios
-                          ) : (
-                            <span className="text-[#aaa]">—</span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          {Number(item.qtd_ativos_linkados || 0).toLocaleString('pt-BR')}
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          {item.origem_st === 'CADASTRADO' && item.exibidor_pk ? (
-                            <button
-                              onClick={() => setDetalheAberto(item.exibidor_pk!)}
-                              className="px-3 py-1.5 rounded-lg bg-[#0a52e6] hover:bg-[#0843b8] text-white text-xs font-medium"
-                            >
-                              Gerenciar
-                            </button>
-                          ) : (
-                            <button
-                              onClick={() =>
-                                setModalAberto({
-                                  tipo: 'do-legado',
-                                  nome_legado: item.nome_st,
-                                  qtd_ativos: item.qtd_ativos_linkados,
-                                })
-                              }
-                              className="px-3 py-1.5 rounded-lg bg-[#ff4600] hover:bg-[#e33d00] text-white text-xs font-medium"
-                            >
-                              Cadastrar
-                            </button>
-                          )}
-                        </td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
-
-            {erro ? (
-              <div className="mt-4 p-3 rounded-lg bg-[#fff5f5] border border-[#f4caca] text-sm text-[#7f1d1d]">
-                {erro}
-              </div>
-            ) : null}
+            <button
+              onClick={() => setModalAberto({ tipo: 'novo' })}
+              className="bg-[#ff4600] hover:bg-[#e33d00] text-white font-medium text-xs h-[34px] px-4 rounded-lg transition-colors"
+            >
+              + Adicionar exibidor novo
+            </button>
           </div>
+
+          {/* Métricas inline */}
+          <div className="flex items-center gap-6 px-6 py-2.5 bg-[#fafafa] border-b border-[#f3f4f6]">
+            <MetricaInline label="Cadastrados" value={stats.cadastrados} cor="#111827" />
+            <MetricaInline label="Pendentes" value={stats.pendentes} cor="#6b7280" />
+            <MetricaInline
+              label="Ativos linkados"
+              value={stats.totalAtivosLinkados.toLocaleString('pt-BR')}
+              cor="#111827"
+            />
+            <MetricaInline
+              label="Ativos sem dono"
+              value={stats.totalAtivosPendentes.toLocaleString('pt-BR')}
+              cor="#6b7280"
+            />
+          </div>
+
+          {/* Filtros */}
+          <div className="flex items-center gap-3 px-6 py-3 flex-wrap border-b border-[#f3f4f6]">
+            <input
+              type="text"
+              placeholder="Buscar por nome..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && carregar()}
+              className="h-[34px] px-3 text-xs border border-[#d9d9d9] rounded-lg w-[260px] focus:outline-none focus:ring-2 focus:ring-[#ff4600]"
+            />
+            <button
+              onClick={carregar}
+              className="h-[34px] px-3 text-xs border border-[#d9d9d9] rounded-lg hover:bg-[#f8f8f8]"
+            >
+              Buscar
+            </button>
+
+            <div className="flex border border-[#d9d9d9] rounded-lg overflow-hidden">
+              {(['TODOS', 'CADASTRADO', 'PENDENTE'] as FiltroOrigem[]).map((f) => (
+                <button
+                  key={f}
+                  onClick={() => setFiltroOrigem(f)}
+                  className={`h-[34px] px-3 text-xs font-medium ${
+                    filtroOrigem === f
+                      ? 'bg-[#ff4600] text-white'
+                      : 'bg-white text-[#3a3a3a] hover:bg-[#f8f8f8]'
+                  }`}
+                >
+                  {f === 'TODOS' ? 'Todos' : f === 'CADASTRADO' ? 'Cadastrados' : 'Pendentes'}
+                </button>
+              ))}
+            </div>
+
+            <label className="flex items-center gap-2 text-xs text-[#3a3a3a] ml-auto">
+              <input
+                type="checkbox"
+                checked={incluirSandbox}
+                onChange={(e) => setIncluirSandbox(e.target.checked)}
+                className="w-4 h-4 accent-[#ff4600]"
+              />
+              Mostrar sandbox
+            </label>
+          </div>
+
+          {/* Tabela full-width */}
+          <div className="w-full">
+            <table className="w-full table-fixed text-sm">
+              <colgroup>
+                <col className="w-[38%]" />
+                <col className="w-[14%]" />
+                <col className="w-[10%]" />
+                <col className="w-[10%]" />
+                <col className="w-[14%]" />
+                <col className="w-[14%]" />
+              </colgroup>
+              <thead>
+                <tr className="border-b border-[#e5e7eb] bg-[#f9fafb]">
+                  <SortableTh col="nome_st" current={sortKey} dir={sortDir} onSort={handleSort}>
+                    Exibidor
+                  </SortableTh>
+                  <SortableTh col="origem_st" current={sortKey} dir={sortDir} onSort={handleSort}>
+                    Status
+                  </SortableTh>
+                  <SortableTh
+                    col="qtd_dominios"
+                    current={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  >
+                    Domínios
+                  </SortableTh>
+                  <SortableTh
+                    col="qtd_usuarios"
+                    current={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  >
+                    Usuários
+                  </SortableTh>
+                  <SortableTh
+                    col="qtd_ativos_linkados"
+                    current={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  >
+                    Ativos legado
+                  </SortableTh>
+                  <th className="px-4 py-2.5 text-right text-[10px] font-semibold uppercase tracking-wider text-[#6b7280]">
+                    Ações
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-12 text-center text-[#666]">
+                      Carregando exibidores...
+                    </td>
+                  </tr>
+                ) : itensOrdenados.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-12 text-center text-[#666]">
+                      Nenhum exibidor encontrado.
+                    </td>
+                  </tr>
+                ) : (
+                  itensOrdenados.map((item) => (
+                    <tr
+                      key={`${item.origem_st}-${item.exibidor_pk ?? item.nome_st}`}
+                      className="border-b border-[#f3f4f6] hover:bg-[#fafafa]"
+                    >
+                      <td className="px-4 py-2.5">
+                        <div className="font-medium text-[#222] truncate" title={item.nome_st}>
+                          {item.nome_st}
+                        </div>
+                        {item.nome_fantasia_st && item.nome_fantasia_st !== item.nome_st ? (
+                          <div className="text-xs text-[#666] truncate">{item.nome_fantasia_st}</div>
+                        ) : null}
+                        {item.cidade_st ? (
+                          <div className="text-xs text-[#888]">
+                            {item.cidade_st}
+                            {item.estado_st ? `/${item.estado_st}` : ''}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        {item.origem_st === 'CADASTRADO' ? (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#e7f3ea] text-[#1f6b2c] text-xs font-medium">
+                            ✓ Cadastrado
+                            {item.sandbox_bl ? (
+                              <span className="ml-1 px-1.5 py-0.5 rounded bg-[#fff5d4] text-[#7a5b00] text-[10px]">
+                                sandbox
+                              </span>
+                            ) : null}
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#fff0e6] text-[#a8410d] text-xs font-medium">
+                            ⚠ Pendente
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        {item.origem_st === 'CADASTRADO' ? (
+                          <span className={item.qtd_dominios === 0 ? 'text-[#a8410d]' : 'text-[#222]'}>
+                            {item.qtd_dominios}
+                          </span>
+                        ) : (
+                          <span className="text-[#aaa]">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        {item.origem_st === 'CADASTRADO' ? (
+                          item.qtd_usuarios
+                        ) : (
+                          <span className="text-[#aaa]">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        {Number(item.qtd_ativos_linkados || 0).toLocaleString('pt-BR')}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        {item.origem_st === 'CADASTRADO' && item.exibidor_pk ? (
+                          <button
+                            onClick={() => setDetalheAberto(item.exibidor_pk!)}
+                            className="px-2.5 py-1 rounded-md text-xs font-medium text-[#6b7280] hover:text-[#111827] hover:bg-[#f3f4f6] transition-colors"
+                          >
+                            Gerenciar →
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() =>
+                              setModalAberto({
+                                tipo: 'do-legado',
+                                nome_legado: item.nome_st,
+                                qtd_ativos: item.qtd_ativos_linkados,
+                              })
+                            }
+                            className="px-2.5 py-1 rounded-md text-xs font-medium text-[#374151] border border-[#d1d5db] hover:text-[#111827] hover:border-[#6b7280] hover:bg-[#f9fafb] transition-colors"
+                          >
+                            Cadastrar
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {erro ? (
+            <div className="mx-6 mt-4 p-3 rounded-lg bg-[#fff5f5] border border-[#f4caca] text-sm text-[#7f1d1d]">
+              {erro}
+            </div>
+          ) : null}
         </div>
 
         {/* Footer */}

--- a/src/screens/GestaoExibidores/ModalCadastroExibidor.tsx
+++ b/src/screens/GestaoExibidores/ModalCadastroExibidor.tsx
@@ -380,7 +380,7 @@ export const ModalCadastroExibidor: React.FC<Props> = ({ mode, onClose, onSucces
                 <button
                   type="button"
                   onClick={adicionarDominio}
-                  className="h-[42px] px-4 bg-[#0a52e6] hover:bg-[#0843b8] text-white rounded-lg font-medium text-sm whitespace-nowrap"
+                  className="h-[42px] px-4 bg-[#111827] hover:bg-[#000] text-white rounded-lg font-medium text-sm whitespace-nowrap"
                 >
                   + Adicionar
                 </button>
@@ -403,7 +403,7 @@ export const ModalCadastroExibidor: React.FC<Props> = ({ mode, onClose, onSucces
                       <div className="flex items-center gap-2">
                         <span className="font-mono text-sm">{d}</span>
                         {idx === 0 ? (
-                          <span className="px-1.5 py-0.5 rounded bg-[#0a52e6] text-white text-[10px] font-bold uppercase">
+                          <span className="px-1.5 py-0.5 rounded bg-[#111827] text-white text-[10px] font-bold uppercase">
                             primário
                           </span>
                         ) : null}


### PR DESCRIPTION
…s e visual minimalista

GestaoExibidores:
- Layout full-width (removido max-w-7xl) com header compacto, métricas em strip horizontal e tabela table-fixed.
- Ordenação default por status (CADASTRADO antes de PENDENTE) com headers clicáveis em todas as colunas relevantes.
- Botões "Gerenciar" e "Cadastrar" em design minimalista (ghost / outline) e troca dos azuis por escala de cinza nas métricas e badges.

DrawerDetalheExibidor:
- Aba "Dados" virou formulário editável (15 campos) com máscara de CNPJ, checkbox de status e footer fixo com botões Cancelar/Salvar.
- Botão Salvar chama op:'editar' já existente no backend, recarrega o detalhe e propaga onChanged() para refletir na listagem.
- Estado dirty controla disable dos botões; mensagem de sucesso inline.

ModalCadastroExibidor / DrawerDetalheExibidor:
- Tons de azul (#0a52e6) substituídos por preto/cinza nos botões de domínios e no badge "primário".