### PR TITLE
feat: migrar processamento de roteiros do Databricks para Logic Apps …

### DIFF
--- a/handlers/databricks-roteiro-simulado.js
+++ b/handlers/databricks-roteiro-simulado.js
@@ -39,88 +39,109 @@ async function databricksRoteiroSimulado(req, res) {
       });
     }
 
-    // Configurações do Databricks
-    const databricksUrl = process.env.DATABRICKS_URL;
-    const databricksJobId = process.env.DATABRICKS_JOB_ID_ROTEIRO_SIMULADO;
-    const authToken = process.env.DATABRICKS_AUTH_TOKEN;
+    // Seleção do motor de execução (rollback fácil via env, sem deploy)
+    const engine = (process.env.EXECUTION_ENGINE || 'logic_app').toLowerCase();
 
-    if (!databricksUrl || !authToken) {
-      console.error('❌ [databricksRoteiroSimulado] DATABRICKS_URL ou DATABRICKS_AUTH_TOKEN não encontrado no .env');
-      return res.status(500).json({
-        success: false,
-        message: 'Configuração do Databricks não encontrada'
-      });
-    }
+    let runId;
+    let statusOk;
+    let downstreamStatus;
 
-    if (!databricksJobId) {
-      console.error('❌ [databricksRoteiroSimulado] DATABRICKS_JOB_ID_ROTEIRO_SIMULADO não encontrado no .env');
-      return res.status(500).json({
-        success: false,
-        message: 'Job ID do roteiro simulado não configurado'
-      });
-    }
-
-    // Corpo da requisição específico para roteiro simulado
-    const requestBody = {
-      job_id: parseInt(databricksJobId),
-      notebook_params: {
-        planoMidiaGrupo_pk: planoMidiaGrupo_pk.toString(),
-        date_dh: date_dh,
-        date_dt: date_dt
+    if (engine === 'logic_app') {
+      const logicAppUrl = process.env.LOGIC_APP_URL_SIMULADO;
+      if (!logicAppUrl) {
+        console.error('❌ [databricksRoteiroSimulado] LOGIC_APP_URL_SIMULADO não encontrado no .env');
+        return res.status(500).json({
+          success: false,
+          message: 'LOGIC_APP_URL_SIMULADO não configurado'
+        });
       }
-    };
 
-    console.log('\n');
-    console.log('═══════════════════════════════════════════════════════════════');
-    console.log('🚀 EXECUTANDO: Databricks Job');
-    console.log('═══════════════════════════════════════════════════════════════');
-    console.log('📊 URL:', databricksUrl);
-    console.log('───────────────────────────────────────────────────────────────');
-    console.log('📊 Job ID:', databricksJobId);
-    console.log('📊 Tipo:', typeof databricksJobId);
-    console.log('───────────────────────────────────────────────────────────────');
-    console.log('📊 REQUEST BODY COMPLETO (que será enviado ao Databricks):');
-    console.log(JSON.stringify(requestBody, null, 2));
-    console.log('───────────────────────────────────────────────────────────────');
-    console.log('📊 notebook_params.planoMidiaGrupo_pk:', requestBody.notebook_params.planoMidiaGrupo_pk);
-    console.log('📊 Tipo:', typeof requestBody.notebook_params.planoMidiaGrupo_pk);
-    console.log('───────────────────────────────────────────────────────────────');
-    console.log('📊 notebook_params.date_dh:', requestBody.notebook_params.date_dh);
-    console.log('📊 Tipo:', typeof requestBody.notebook_params.date_dh);
-    console.log('───────────────────────────────────────────────────────────────');
-    console.log('📊 notebook_params.date_dt:', requestBody.notebook_params.date_dt);
-    console.log('📊 Tipo:', typeof requestBody.notebook_params.date_dt);
-    console.log('═══════════════════════════════════════════════════════════════');
+      const payload = {
+        planoMidiaGrupo_pk: planoMidiaGrupo_pk.toString(),
+        date_dh,
+        date_dt
+      };
 
-    // Executar job no Databricks
-    const databricksResponse = await axios.post(databricksUrl, requestBody, {
-      headers: {
-        'Authorization': `Bearer ${authToken}`,
-        'Content-Type': 'application/json'
-      },
-      timeout: 30000 // 30 segundos timeout
-    });
+      console.log('\n');
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log('🚀 EXECUTANDO: Logic App (Simulado)');
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log('📊 URL:', logicAppUrl.slice(0, 80) + '…');
+      console.log('📦 PAYLOAD:', JSON.stringify(payload));
+      console.log('═══════════════════════════════════════════════════════════════');
 
-    if (databricksResponse.status === 200) {
-      const runId = databricksResponse.data.run_id;
-      
-      console.log('✅ [databricksRoteiroSimulado] Job executado com sucesso!');
-      console.log(`📋 Run ID: ${runId}`);
-      
-      res.json({
-        success: true,
-        message: 'Processamento Databricks iniciado com sucesso para roteiro simulado',
-        data: {
-          run_id: runId,
-          job_id: databricksJobId,
-          planoMidiaGrupo_pk: planoMidiaGrupo_pk, // PK do grupo processado
-          parameters: requestBody.notebook_params,
-          status: 'RUNNING'
-        }
+      const logicAppResponse = await axios.post(logicAppUrl, payload, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 60000,
+        validateStatus: s => s === 200 || s === 202 // Logic App responde 202 (assíncrono)
       });
+
+      downstreamStatus = logicAppResponse.status;
+      runId = logicAppResponse.headers['x-ms-workflow-run-id'] || 'unknown';
+      statusOk = (logicAppResponse.status === 200 || logicAppResponse.status === 202);
     } else {
-      throw new Error(`Databricks retornou status ${databricksResponse.status}`);
+      // legacy databricks (manter pra rollback rápido — remover após sign-off)
+      const databricksUrl = process.env.DATABRICKS_URL;
+      const databricksJobId = process.env.DATABRICKS_JOB_ID_ROTEIRO_SIMULADO;
+      const authToken = process.env.DATABRICKS_AUTH_TOKEN;
+
+      if (!databricksUrl || !authToken || !databricksJobId) {
+        console.error('❌ [databricksRoteiroSimulado] Configuração do Databricks ausente no .env');
+        return res.status(500).json({
+          success: false,
+          message: 'Configuração do Databricks não encontrada'
+        });
+      }
+
+      const requestBody = {
+        job_id: parseInt(databricksJobId),
+        notebook_params: {
+          planoMidiaGrupo_pk: planoMidiaGrupo_pk.toString(),
+          date_dh,
+          date_dt
+        }
+      };
+
+      console.log('\n');
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log('🚀 EXECUTANDO: Databricks Job (Simulado)');
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log('📊 URL:', databricksUrl);
+      console.log('📊 Job ID:', databricksJobId);
+      console.log('📊 REQUEST BODY:', JSON.stringify(requestBody, null, 2));
+      console.log('═══════════════════════════════════════════════════════════════');
+
+      const databricksResponse = await axios.post(databricksUrl, requestBody, {
+        headers: {
+          'Authorization': `Bearer ${authToken}`,
+          'Content-Type': 'application/json'
+        },
+        timeout: 30000 // 30 segundos timeout
+      });
+
+      downstreamStatus = databricksResponse.status;
+      runId = databricksResponse.data?.run_id;
+      statusOk = (databricksResponse.status === 200);
     }
+
+    if (!statusOk) {
+      throw new Error(`Engine ${engine} retornou status ${downstreamStatus}`);
+    }
+
+    console.log(`✅ [databricksRoteiroSimulado] Processamento (${engine}) iniciado!`);
+    console.log(`📋 Run ID: ${runId}`);
+
+    res.json({
+      success: true,
+      message: `Processamento (${engine}) iniciado com sucesso para roteiro simulado`,
+      data: {
+        run_id: runId,
+        engine,
+        planoMidiaGrupo_pk: planoMidiaGrupo_pk, // PK do grupo processado
+        parameters: { planoMidiaGrupo_pk, date_dh, date_dt },
+        status: 'RUNNING'
+      }
+    });
 
   } catch (error) {
     console.error('❌ [databricksRoteiroSimulado] Erro:', error);

--- a/handlers/databricks-run-job.js
+++ b/handlers/databricks-run-job.js
@@ -18,20 +18,7 @@ async function databricksRunJob(req, res) {
             });
         }
 
-        const databricksUrl = process.env.DATABRICKS_URL;
-        const jobId = parseInt(process.env.DATABRICKS_JOB_ID);
-        const authToken = process.env.DATABRICKS_AUTH_TOKEN;
-
-        // Validar se as variáveis de ambiente estão configuradas
-        if (!databricksUrl || !jobId || !authToken) {
-            return res.status(500).json({
-                success: false,
-                error: 'Configurações do Databricks não encontradas',
-                message: 'Configure as variáveis de ambiente DATABRICKS_URL, DATABRICKS_JOB_ID e DATABRICKS_AUTH_TOKEN'
-            });
-        }
-
-        console.log(`✅ [databricksRunJob] Executando job do Databricks para grupo ${planoMidiaGrupo_pk}`);
+        const engine = (process.env.EXECUTION_ENGINE || 'logic_app').toLowerCase();
 
         // Converter date_dh para o formato solicitado
         const dateDh = new Date(date_dh);
@@ -40,25 +27,83 @@ async function databricksRunJob(req, res) {
 
         console.log(`📅 [databricksRunJob] Parâmetros formatados - date_dh: ${formattedDateDh}, date_dt: ${formattedDateDt}`);
 
-        const jobPayload = {
-            job_id: jobId,
-            notebook_params: {
-                planoMidiaGrupo_pk: planoMidiaGrupo_pk.toString(),
-                date_dh: formattedDateDh,
-                date_dt: formattedDateDt
-            }
-        };
-
         try {
-            const response = await axios.post(databricksUrl, jobPayload, {
-                headers: {
-                    'Authorization': `Bearer ${authToken}`,
-                    'Content-Type': 'application/json'
-                },
-                timeout: 30000 // 30 segundos timeout
-            });
+            let runId;
+            let statusOk;
+            let downstreamStatus;
+            let rawResponse;
 
-            console.log(`✅ [databricksRunJob] Job iniciado para grupo ${planoMidiaGrupo_pk} - Run ID: ${response.data.run_id}`);
+            if (engine === 'logic_app') {
+                const logicAppUrl = process.env.LOGIC_APP_URL_COMPLETO;
+                if (!logicAppUrl) {
+                    return res.status(500).json({
+                        success: false,
+                        message: 'LOGIC_APP_URL_COMPLETO não configurado'
+                    });
+                }
+
+                const payload = {
+                    planoMidiaGrupo_pk: planoMidiaGrupo_pk.toString(),
+                    date_dh: formattedDateDh,
+                    date_dt: formattedDateDt
+                };
+
+                console.log(`🚀 [databricksRunJob] Executando Logic App (Completo) para grupo ${planoMidiaGrupo_pk}`);
+
+                const response = await axios.post(logicAppUrl, payload, {
+                    headers: { 'Content-Type': 'application/json' },
+                    timeout: 60000,
+                    validateStatus: s => s === 200 || s === 202
+                });
+
+                downstreamStatus = response.status;
+                runId = response.headers['x-ms-workflow-run-id'] || 'unknown';
+                statusOk = (response.status === 200 || response.status === 202);
+                rawResponse = response.data;
+            } else {
+                // legacy databricks (manter pra rollback rápido — remover após sign-off)
+                const databricksUrl = process.env.DATABRICKS_URL;
+                const jobId = parseInt(process.env.DATABRICKS_JOB_ID);
+                const authToken = process.env.DATABRICKS_AUTH_TOKEN;
+
+                if (!databricksUrl || !jobId || !authToken) {
+                    return res.status(500).json({
+                        success: false,
+                        error: 'Configurações do Databricks não encontradas',
+                        message: 'Configure as variáveis de ambiente DATABRICKS_URL, DATABRICKS_JOB_ID e DATABRICKS_AUTH_TOKEN'
+                    });
+                }
+
+                const jobPayload = {
+                    job_id: jobId,
+                    notebook_params: {
+                        planoMidiaGrupo_pk: planoMidiaGrupo_pk.toString(),
+                        date_dh: formattedDateDh,
+                        date_dt: formattedDateDt
+                    }
+                };
+
+                console.log(`🚀 [databricksRunJob] Executando Databricks Job (Completo) para grupo ${planoMidiaGrupo_pk}`);
+
+                const response = await axios.post(databricksUrl, jobPayload, {
+                    headers: {
+                        'Authorization': `Bearer ${authToken}`,
+                        'Content-Type': 'application/json'
+                    },
+                    timeout: 30000 // 30 segundos timeout
+                });
+
+                downstreamStatus = response.status;
+                runId = response.data?.run_id;
+                statusOk = (response.status === 200);
+                rawResponse = response.data;
+            }
+
+            if (!statusOk) {
+                throw new Error(`Engine ${engine} retornou status ${downstreamStatus}`);
+            }
+
+            console.log(`✅ [databricksRunJob] Job (${engine}) iniciado para grupo ${planoMidiaGrupo_pk} - Run ID: ${runId}`);
 
             // Retornar resultado de sucesso
             res.json({
@@ -71,14 +116,15 @@ async function databricksRunJob(req, res) {
                 result: {
                     planoMidiaGrupo_pk: planoMidiaGrupo_pk,
                     success: true,
-                    run_id: response.data.run_id,
-                    databricks_response: response.data
+                    run_id: runId,
+                    engine,
+                    databricks_response: rawResponse
                 },
-                message: `Job do Databricks executado com sucesso para grupo ${planoMidiaGrupo_pk}`
+                message: `Processamento (${engine}) executado com sucesso para grupo ${planoMidiaGrupo_pk}`
             });
 
         } catch (error) {
-            console.error(`❌ [databricksRunJob] Erro no job para grupo ${planoMidiaGrupo_pk}:`, error.message);
+            console.error(`❌ [databricksRunJob] Erro no job (${engine}) para grupo ${planoMidiaGrupo_pk}:`, error.message);
             
             res.json({
                 success: false,
@@ -93,7 +139,7 @@ async function databricksRunJob(req, res) {
                     error: error.message,
                     response: error.response?.data || null
                 },
-                message: `Erro ao executar job do Databricks para grupo ${planoMidiaGrupo_pk}`
+                message: `Erro ao executar processamento (${engine}) para grupo ${planoMidiaGrupo_pk}`
             });
         }
 


### PR DESCRIPTION
…BE180

Adiciona feature flag EXECUTION_ENGINE (logic_app|databricks) nos handlers Simulado e Completo. No modo logic_app, envia payload na raiz sem header de auth (SAS na query-string), timeout de 60s, aceita 200/202 e rastreia via header x-ms-workflow-run-id. Branch legacy do Databricks preservado para rollback rápido sem deploy. Contrato com o front mantido.