### PR TITLE
fix: corrige valor importado dobrado na tela Nomear Roteiro

### DIFF
--- a/src/utils/parsePlanoOohExcel.ts
+++ b/src/utils/parsePlanoOohExcel.ts
@@ -312,11 +312,15 @@ export async function parsePlanoOohExcel(file: File): Promise<ParsePlanoOohResul
       }
     }
 
-    // Soma apenas uma vez por linha (valorLiquido ou totalFinal)
-    const v = record.valorLiquido_vl ?? record.totalFinal_vl;
-    if (typeof v === 'number') valorTotalSuggestion += v;
+    const willInsert = rowPassesSPFilter(record);
 
-    rows.push({ ...record, _index: rowIdx + 1, _willInsert: rowPassesSPFilter(record) });
+    // Soma apenas linhas de praça individuais (exclui subtotais e totais gerais)
+    if (willInsert) {
+      const v = record.valorLiquido_vl ?? record.totalFinal_vl;
+      if (typeof v === 'number') valorTotalSuggestion += v;
+    }
+
+    rows.push({ ...record, _index: rowIdx + 1, _willInsert: willInsert });
   }
 
   if (rows.length === 0) throw new Error('Nenhuma linha de dados encontrada na aba OOH.');


### PR DESCRIPTION
Valor aprovado da campanha estava somando linhas de subtotal junto com as linhas individuais de praça, inflando o total. Agora só soma linhas que passam no rowPassesSPFilter (linhas reais de praça com exibidor, formato e datas preenchidos), excluindo subtotais e totais gerais.