### PR TITLE
feat: coluna STATUS de negócio em Meus Roteiros

### DIFF
--- a/api/roteiros.js
+++ b/api/roteiros.js
@@ -7,6 +7,8 @@ const handlers = {
   'simulado': require('../handlers/roteiro-simulado'),
   'completo': require('../handlers/roteiro-completo'),
   'liberar-agencia': require('../handlers/roteiros-liberar-agencia'),
+  'status-list': require('../handlers/roteiros-status-list'),
+  'atualizar-status': require('../handlers/roteiros-atualizar-status'),
 };
 
 module.exports = async (req, res) => {

--- a/handlers/roteiros-atualizar-status.js
+++ b/handlers/roteiros-atualizar-status.js
@@ -1,0 +1,45 @@
+const { getPool } = require('./db');
+const { requireInternalUser } = require('./auth-middleware');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'PUT') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  // Apenas usuários internos BE (empresa_pk = null) podem trocar status
+  if (!requireInternalUser(req, res)) return;
+
+  try {
+    const { planoMidiaGrupo_pk, planoMidiaStatus_pk } = req.body;
+
+    if (!planoMidiaGrupo_pk || !Number.isInteger(Number(planoMidiaGrupo_pk)) || Number(planoMidiaGrupo_pk) <= 0) {
+      return res.status(400).json({ error: 'planoMidiaGrupo_pk deve ser um inteiro positivo' });
+    }
+
+    if (!planoMidiaStatus_pk || !Number.isInteger(Number(planoMidiaStatus_pk)) || Number(planoMidiaStatus_pk) <= 0) {
+      return res.status(400).json({ error: 'planoMidiaStatus_pk deve ser um inteiro positivo' });
+    }
+
+    const pool = await getPool();
+
+    try {
+      await pool.request()
+        .input('planoMidiaGrupo_pk', Number(planoMidiaGrupo_pk))
+        .input('planoMidiaStatus_pk', Number(planoMidiaStatus_pk))
+        .execute('serv_product_be180.sp_planoMidiaGrupoUpdateStatus');
+    } catch (spErr) {
+      // RAISERROR do SP → HTTP 400 com a mensagem original
+      const msg = spErr?.message || 'Status inválido ou inativo';
+      return res.status(400).json({ error: msg });
+    }
+
+    res.json({
+      success: true,
+      planoMidiaGrupo_pk: Number(planoMidiaGrupo_pk),
+      planoMidiaStatus_pk: Number(planoMidiaStatus_pk),
+    });
+  } catch (err) {
+    console.error('Erro ao atualizar status do roteiro:', err);
+    res.status(500).json({ error: 'Erro interno do servidor' });
+  }
+};

--- a/handlers/roteiros-status-list.js
+++ b/handlers/roteiros-status-list.js
@@ -1,0 +1,21 @@
+const { getPool } = require('./db');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Método não permitido' });
+  }
+
+  try {
+    const pool = await getPool();
+    const result = await pool.request().query(`
+      SELECT pk, planoMidiaStatus_st, hexColor_st, ordem_vl
+      FROM serv_product_be180.planoMidiaStatus_dm_vw
+      ORDER BY ordem_vl
+    `);
+
+    res.json({ success: true, data: result.recordset });
+  } catch (err) {
+    console.error('Erro ao listar status de plano de mídia:', err);
+    res.status(500).json({ error: 'Erro interno do servidor' });
+  }
+};

--- a/src/screens/MeusRoteiros/MeusRoteiros.tsx
+++ b/src/screens/MeusRoteiros/MeusRoteiros.tsx
@@ -42,6 +42,17 @@ interface Roteiro {
   delete_bl: number;
   liberadoAgencia_bl?: number;
   agencia_st?: string;
+  // Campos de status de negócio (novos)
+  planoMidiaStatus_pk: number;
+  planoMidiaStatus_st: string;
+  statusHexColor_st: string;
+}
+
+interface StatusOpcao {
+  pk: number;
+  planoMidiaStatus_st: string;
+  hexColor_st: string;
+  ordem_vl: number;
 }
 
 interface PaginationInfo {
@@ -74,7 +85,8 @@ export const MeusRoteiros: React.FC = () => {
     roteiro: null
   });
   const [isDeleting, setIsDeleting] = useState(false);
-  
+  const [statusOpcoes, setStatusOpcoes] = useState<StatusOpcao[]>([]);
+
   // Aplicar debounce ao termo de busca (300ms)
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
@@ -160,6 +172,13 @@ export const MeusRoteiros: React.FC = () => {
     carregarDados(1);
   }, []);
 
+  // Carregar opções de status (apenas para usuários internos — mas o endpoint é aberto para leitura)
+  useEffect(() => {
+    api.get('/roteiros?action=status-list')
+      .then((res) => setStatusOpcoes(res.data.data || []))
+      .catch((err) => console.error('Erro ao carregar opções de status:', err));
+  }, []);
+
   // Effect para busca com debounce
   useEffect(() => {
     if (debouncedSearchTerm && debouncedSearchTerm.length >= 2) {
@@ -222,6 +241,39 @@ Email: suporte@be180.com.br`;
     } catch (err: any) {
       console.error('Erro ao liberar roteiro:', err);
       setErro(err.response?.data?.error || 'Erro ao alterar liberação');
+    }
+  };
+
+  const handleChangeStatus = async (
+    roteiro: Roteiro,
+    novoStatusPk: number,
+    novoStatusSt: string,
+    novoHex: string
+  ) => {
+    // Update otimista
+    setDados((prev) =>
+      prev.map((r) =>
+        r.planoMidiaGrupo_pk === roteiro.planoMidiaGrupo_pk
+          ? { ...r, planoMidiaStatus_pk: novoStatusPk, planoMidiaStatus_st: novoStatusSt, statusHexColor_st: novoHex }
+          : r
+      )
+    );
+    try {
+      await api.put('/roteiros?action=atualizar-status', {
+        planoMidiaGrupo_pk: roteiro.planoMidiaGrupo_pk,
+        planoMidiaStatus_pk: novoStatusPk,
+      });
+    } catch (err: any) {
+      console.error('Erro ao atualizar status:', err);
+      setErro(err.response?.data?.error || 'Erro ao atualizar status do roteiro');
+      // Reverter update otimista
+      setDados((prev) =>
+        prev.map((r) =>
+          r.planoMidiaGrupo_pk === roteiro.planoMidiaGrupo_pk
+            ? { ...r, planoMidiaStatus_pk: roteiro.planoMidiaStatus_pk, planoMidiaStatus_st: roteiro.planoMidiaStatus_st, statusHexColor_st: roteiro.statusHexColor_st }
+            : r
+        )
+      );
     }
   };
 
@@ -364,11 +416,16 @@ Email: suporte@be180.com.br`;
                       Data de criação
                     </th>
                     <th
+                      className="text-white text-xs font-bold uppercase text-left px-6 py-2 tracking-wider font-sans"
+                    >
+                      Status
+                    </th>
+                    <th
                       className="text-white text-xs font-bold uppercase text-left px-6 py-2 tracking-wider font-sans cursor-pointer hover:text-[#FF9800] transition-colors duration-200"
                       tabIndex={0}
                       role="button"
                     >
-                      Status do roteiro
+                      Processamento
                     </th>
                     <th
                       className="text-white text-xs font-bold uppercase text-left px-6 py-2 tracking-wider font-sans cursor-pointer hover:text-[#FF9800] transition-colors duration-200"
@@ -390,11 +447,11 @@ Email: suporte@be180.com.br`;
                     <TableSkeleton />
                   ) : erro ? (
                     <tr>
-                      <td colSpan={isAgencia ? 5 : 6} className="text-center py-4 text-red-500">{erro}</td>
-                    </tr>
+                    <td colSpan={isAgencia ? 6 : 7} className="text-center py-4 text-red-500">{erro}</td>
+                  </tr>
                   ) : dados.length === 0 ? (
                     <tr>
-                      <td colSpan={isAgencia ? 5 : 6} className="text-center py-4">
+                      <td colSpan={isAgencia ? 6 : 7} className="text-center py-4">
                         {isSearching ? "Nenhum roteiro encontrado com esse termo" : "Nenhum roteiro encontrado"}
                       </td>
                     </tr>
@@ -406,6 +463,49 @@ Email: suporte@be180.com.br`;
                       >
                         <td className="text-[#222] text-sm font-normal px-6 py-4 whitespace-nowrap font-sans max-w-xs truncate">{item.planoMidiaGrupo_st}</td>
                         <td className="text-[#222] text-sm font-normal px-6 py-4 whitespace-nowrap font-sans">{formatarData(item.date_dh)}</td>
+
+                        {/* Coluna STATUS — badge + dropdown (só interno) */}
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          {(() => {
+                            const hex = item.statusHexColor_st || '#6b7280';
+                            const label = item.planoMidiaStatus_st || 'Teste';
+                            const badge = (
+                              <span
+                                style={{ color: hex, backgroundColor: `${hex}1A` }}
+                                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold whitespace-nowrap"
+                              >
+                                <span style={{ backgroundColor: hex }} className="w-1.5 h-1.5 rounded-full flex-shrink-0" />
+                                {label}
+                              </span>
+                            );
+
+                            if (isAgencia) return badge;
+
+                            // Interno: select estilizado + badge de preview
+                            return (
+                              <select
+                                value={item.planoMidiaStatus_pk || ''}
+                                onChange={(e) => {
+                                  const pk = parseInt(e.target.value, 10);
+                                  const opt = statusOpcoes.find((s) => s.pk === pk);
+                                  if (opt) handleChangeStatus(item, pk, opt.planoMidiaStatus_st, opt.hexColor_st);
+                                }}
+                                style={{ borderColor: hex, color: hex }}
+                                className="text-xs font-semibold rounded-full px-2.5 py-1 bg-white border-2 focus:outline-none focus:ring-1 cursor-pointer appearance-none pr-5"
+                                title="Alterar status do roteiro"
+                              >
+                                {statusOpcoes.length === 0 && (
+                                  <option value={item.planoMidiaStatus_pk}>{label}</option>
+                                )}
+                                {statusOpcoes.map((s) => (
+                                  <option key={s.pk} value={s.pk}>{s.planoMidiaStatus_st}</option>
+                                ))}
+                              </select>
+                            );
+                          })()}
+                        </td>
+
+                        {/* Coluna PROCESSAMENTO (antes "Status do roteiro") */}
                         <td className="text-[#222] text-sm font-normal px-6 py-4 whitespace-nowrap font-sans">
                           {item.inProgress_bl === 1 ? (
                             <div className="flex items-center gap-2">

--- a/src/screens/MeusRoteiros/components/TableSkeleton/TableSkeleton.tsx
+++ b/src/screens/MeusRoteiros/components/TableSkeleton/TableSkeleton.tsx
@@ -15,7 +15,11 @@ const SkeletonRow: React.FC<SkeletonRowProps> = ({ isEven }) => {
       <td className="px-6 py-4">
         <div className="h-4 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-shimmer bg-[length:200%_100%] w-24"></div>
       </td>
-      {/* Tipo de Roteiro / Status */}
+      {/* Status (negócio) */}
+      <td className="px-6 py-4">
+        <div className="h-6 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded-full animate-shimmer bg-[length:200%_100%] w-20"></div>
+      </td>
+      {/* Processamento */}
       <td className="px-6 py-4">
         <div className="h-4 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-shimmer bg-[length:200%_100%] w-28"></div>
       </td>


### PR DESCRIPTION
Backend:
- handlers/roteiros-status-list.js: GET lista planoMidiaStatus_dm_vw
- handlers/roteiros-atualizar-status.js: PUT via SP sp_planoMidiaGrupoUpdateStatus com requireInternalUser + validação de inteiros + mapeamento RAISERROR→400
- api/roteiros.js: registra actions 'status-list' e 'atualizar-status'

Frontend (MeusRoteiros.tsx):
- Interface Roteiro: +planoMidiaStatus_pk, +planoMidiaStatus_st, +statusHexColor_st
- Interface StatusOpcao + estado statusOpcoes carregado no mount
- handleChangeStatus: update otimista com rollback em caso de erro
- Header "Status do roteiro" renomeado para "PROCESSAMENTO"
- Nova coluna "STATUS" antes de PROCESSAMENTO: • isAgencia → badge pill (cor do banco via statusHexColor_st, bg 10% alpha) • Interno BE → <select> estilizado com borda colorida + todas as opções da dimensão
- colSpan de empty-state/erro ajustados (isAgencia 5→6, interno 6→7)
- TableSkeleton: novo td de skeleton pill para a coluna STATUS