### PR TITLE
feat(indoor): permite finalizar o roteiro direto da aba Indoor

### DIFF
--- a/src/components/ConfigurarIndoor/ConfigurarIndoor.tsx
+++ b/src/components/ConfigurarIndoor/ConfigurarIndoor.tsx
@@ -18,6 +18,12 @@ interface Props {
   cidadesSalvas: Cidade[];
   quantidadeSemanas: number;
   onVoltarAba4: () => void;
+  /** Dispara a finalização completa do roteiro (mesma lógica da Aba 4). */
+  onFinalizarRoteiro?: () => void;
+  /** True enquanto a finalização do roteiro está em andamento. */
+  finalizandoRoteiro?: boolean;
+  /** True quando as Vias Públicas já estão prontas para finalizar. */
+  podeFinalizarRoteiro?: boolean;
 }
 
 interface PracaSalva {
@@ -39,6 +45,9 @@ export default function ConfigurarIndoor({
   cidadesSalvas,
   quantidadeSemanas,
   onVoltarAba4,
+  onFinalizarRoteiro,
+  finalizandoRoteiro = false,
+  podeFinalizarRoteiro = false,
 }: Props) {
   const [dims, setDims] = useState<IndoorDims | null>(null);
   const [loadingDims, setLoadingDims] = useState(true);
@@ -269,7 +278,7 @@ export default function ConfigurarIndoor({
                   : `${pracasSalvas.length} de ${pracasDisponiveis.length} praça(s) configurada(s)`}
               </p>
               <p className="text-xs text-gray-400 mt-1">
-                A finalização do roteiro acontece na Aba 4. Clique abaixo para continuar.
+                Você pode finalizar o roteiro agora mesmo, sem voltar à Aba 4.
               </p>
             </div>
 
@@ -285,14 +294,50 @@ export default function ConfigurarIndoor({
             )}
 
             <div className="flex flex-col items-center gap-2 w-full pt-2">
+              {onFinalizarRoteiro && (
+                <>
+                  <button
+                    type="button"
+                    onClick={onFinalizarRoteiro}
+                    disabled={!podeFinalizarRoteiro || finalizandoRoteiro}
+                    className="w-full max-w-xs rounded-lg bg-[#ff4600] px-6 py-2.5 text-sm font-semibold text-white hover:brightness-95 transition-all disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  >
+                    {finalizandoRoteiro ? (
+                      <>
+                        <span className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                        Finalizando roteiro…
+                      </>
+                    ) : (
+                      'Finalizar roteiro e ver resultados'
+                    )}
+                  </button>
+                  {finalizandoRoteiro && (
+                    <p className="text-[11px] text-gray-400 text-center max-w-xs">
+                      Isso pode levar até 2 minutos. Você será levado aos resultados automaticamente.
+                    </p>
+                  )}
+                  {!podeFinalizarRoteiro && !finalizandoRoteiro && (
+                    <p className="text-[11px] text-amber-600 text-center max-w-xs">
+                      Configure e carregue as Vias Públicas (Aba 4) antes de finalizar o roteiro.
+                    </p>
+                  )}
+                </>
+              )}
+
               <button
                 type="button"
                 onClick={onVoltarAba4}
-                className="w-full max-w-xs rounded-lg bg-[#ff4600] px-6 py-2.5 text-sm font-semibold text-white hover:brightness-95 transition-all"
+                disabled={finalizandoRoteiro}
+                className={`text-xs ${
+                  onFinalizarRoteiro
+                    ? 'text-gray-400 hover:text-[#3a3a3a]'
+                    : 'w-full max-w-xs rounded-lg bg-[#ff4600] px-6 py-2.5 text-sm font-semibold text-white hover:brightness-95 transition-all'
+                } disabled:opacity-40 disabled:cursor-not-allowed`}
               >
-                Voltar para Aba 4 e finalizar roteiro
+                {onFinalizarRoteiro ? '← Voltar para Aba 4 (Vias Públicas)' : 'Voltar para Aba 4 e finalizar roteiro'}
               </button>
-              {pracasSalvas.length < pracasDisponiveis.length && (
+
+              {pracasSalvas.length < pracasDisponiveis.length && !finalizandoRoteiro && (
                 <button
                   type="button"
                   onClick={() => setStepIdx(pracasDisponiveis.findIndex((p) => !pracasSalvas.some((ps) => ps.praca === p)))}

--- a/src/screens/CriarRoteiro/CriarRoteiro.tsx
+++ b/src/screens/CriarRoteiro/CriarRoteiro.tsx
@@ -4611,7 +4611,7 @@ export const CriarRoteiro: React.FC = () => {
                     </h3>
                     <p className="text-sm text-gray-500 mt-1">
                       Etapa opcional. Configure e salve os ambientes indoor do seu roteiro.
-                      A finalização do roteiro acontece na Aba 4 (Vias Públicas).
+                      Ao final você pode finalizar o roteiro por aqui mesmo, sem voltar à Aba 4.
                     </p>
                   </div>
 
@@ -4623,6 +4623,18 @@ export const CriarRoteiro: React.FC = () => {
                       setAba5Preenchida(true);
                       setAbaAtiva(4);
                     }}
+                    onFinalizarRoteiro={() => {
+                      setAba5Preenchida(true);
+                      salvarAba4();
+                    }}
+                    finalizandoRoteiro={salvandoAba4}
+                    podeFinalizarRoteiro={
+                      !!planoMidiaGrupo_pk &&
+                      !!targetSalvoLocal?.salvo &&
+                      planoMidia_pks.length > 0 &&
+                      roteirosCarregados.length > 0 &&
+                      validarConsistenciaCidades().valido
+                    }
                   />
 
                   <div className="mt-6 pt-4 border-t border-gray-200">


### PR DESCRIPTION
Elimina o vai-e-volta de usabilidade: antes o usuário precisava configurar o indoor na Aba 5 e voltar para a Aba 4 (Vias Públicas) para finalizar.

Agora a etapa de conclusão do wizard indoor tem o botão "Finalizar roteiro e ver resultados", que dispara a mesma finalização da Aba 4 (upload, stored procedures, backfill indoor e Databricks) e navega direto para os resultados.

O botão só habilita quando as Vias Públicas já estão prontas (target salvo, planos criados, roteiros carregados e cidades consistentes), preservando a dependência de quantidadeSemanas definida na Aba 4. Quem não usa indoor continua finalizando normalmente pela Aba 4.