### PR TITLE
fix: adiciona ErrorBoundary e corrige tela branca na navegação

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  chunkError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null, chunkError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    const chunkError =
+      error?.name === 'ChunkLoadError' ||
+      /loading chunk/i.test(error?.message || '') ||
+      /failed to fetch dynamically imported module/i.test(error?.message || '');
+    return { hasError: true, error, chunkError };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[ErrorBoundary] erro capturado:', error, info.componentStack);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  handleGoHome = () => {
+    window.location.href = '/';
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    const { chunkError, error } = this.state;
+
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center p-6 font-sans">
+        <div className="max-w-md w-full text-center">
+          <div className="w-16 h-16 bg-orange-50 rounded-full flex items-center justify-center mx-auto mb-6">
+            <svg
+              className="w-8 h-8 text-[#ff4600]"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+              />
+            </svg>
+          </div>
+
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            {chunkError ? 'Nova versão disponível' : 'Algo deu errado'}
+          </h1>
+
+          <p className="text-sm text-gray-500 mb-8 leading-relaxed">
+            {chunkError
+              ? 'A plataforma foi atualizada. Recarregue a página para continuar.'
+              : 'Ocorreu um erro inesperado durante a navegação. Tente recarregar a página.'}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <button
+              onClick={this.handleReload}
+              className="inline-flex items-center justify-center gap-2 h-11 px-6 rounded-lg bg-[#ff4600] hover:bg-[#e33d00] active:scale-95 text-white text-sm font-semibold transition-all shadow-sm"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582M20 20v-5h-.581M5.635 19A9 9 0 104.583 9.5" />
+              </svg>
+              Recarregar página
+            </button>
+            <button
+              onClick={this.handleGoHome}
+              className="inline-flex items-center justify-center gap-2 h-11 px-6 rounded-lg border border-gray-200 hover:border-gray-300 text-gray-700 text-sm font-medium transition-all"
+            >
+              Ir para o início
+            </button>
+          </div>
+
+          {!chunkError && error?.message && (
+            <p className="mt-8 text-[11px] text-gray-300 font-mono break-all">
+              {error.message}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { Auth0Provider } from "@auth0/auth0-react";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import { ProtectedRoute } from "./components/ProtectedRoute/ProtectedRoute";
 import { OcorrenciaWidget } from "./components/OcorrenciaWidget/OcorrenciaWidget";
+import { ErrorBoundary } from "./components/ErrorBoundary/ErrorBoundary";
 import '../tailwind.css';
 import 'leaflet/dist/leaflet.css';
 
@@ -66,7 +67,16 @@ function AppGuard({ children }: { children: React.ReactNode }) {
 // Redireciona exibidores para /exibidor/dashboard; demais usuários ficam no HomeDashboard
 function HomeGuard() {
   const { isExibidor, isLoading } = useAuth();
-  if (isLoading) return null; // ProtectedRoute já cuida do spinner
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-10 h-10 border-4 border-gray-200 border-t-[#ff4600] rounded-full animate-spin" />
+          <p className="text-sm text-gray-500">Carregando...</p>
+        </div>
+      </div>
+    );
+  }
   if (isExibidor) return <Navigate to="/exibidor/dashboard" replace />;
   return <HomeDashboard />;
 }
@@ -90,6 +100,7 @@ root.render(
       <AuthProvider>
         <BrowserRouter>
           <AppGuard>
+            <ErrorBoundary>
             <Suspense fallback={<PageLoader />}>
               <Routes>
                 <Route path="/login"    element={<Login />} />
@@ -222,6 +233,7 @@ root.render(
                 <Route path="*" element={<div>Página não encontrada</div>} />
               </Routes>
             </Suspense>
+            </ErrorBoundary>
           </AppGuard>
         </BrowserRouter>
       </AuthProvider>


### PR DESCRIPTION
- Cria ErrorBoundary global que captura erros de render e falhas de chunk lazy, exibindo tela amigável com opção de recarregar em vez de deixar a página completamente em branco
- Corrige HomeGuard que retornava null durante isLoading, causando flash de tela branca em transições de auth