### PR TITLE
Feat/admin cadastrar pracas

### DIFF
--- a/api/admin.js
+++ b/api/admin.js
@@ -8,6 +8,7 @@ const handlers = {
   'verificar-acesso': require('../handlers/verificar-acesso'),
   'inventario-analise': require('../handlers/admin-inventario-analise'),
   'exibidores-dashboard': require('../handlers/exibidores-dashboard'),
+  'pracas-admin': require('../handlers/pracas-admin'),
 };
 
 module.exports = async (req, res) => {

--- a/handlers/cidades-praca.js
+++ b/handlers/cidades-praca.js
@@ -1,29 +1,66 @@
 const { sql, getPool } = require('./db');
 
+/**
+ * GET /cidades-praca
+ *
+ * Retorna lista canônica de praças para uso em dropdowns.
+ * Fonte: UNION de:
+ *  1. [cidadeIbge_dm]        — todos os 5570 municípios brasileiros (IBGE)
+ *  2. [bancoAtivosJoin_ft]   — cidades do banco de ativos legado (fallback/complemento)
+ *  3. [praca_canonica_dm]    — praças customizadas cadastradas pelo admin (se a tabela existir)
+ *
+ * Query param: search (opcional) — filtra por nome ou UF
+ */
 module.exports = async (req, res) => {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Método não permitido' });
   }
 
   try {
-    const pool    = await getPool();
-    const search  = (req.query.search || '').replace(/\+/g, ' ').trim();
-    const request = pool.request();
+    const pool   = await getPool();
+    const search = (req.query.search || '').replace(/\+/g, ' ').trim();
+    const req_   = pool.request();
 
-    let where = 'WHERE valid_bl = 1 AND cidade_st IS NOT NULL';
+    let searchFilter = '';
     if (search) {
-      request.input('search', sql.NVarChar, `%${search}%`);
-      where += ' AND (cidade_st LIKE @search OR estado_st LIKE @search)';
+      req_.input('search', sql.NVarChar, `%${search}%`);
+      searchFilter = 'AND (nome_cidade LIKE @search OR nome_estado LIKE @search)';
     }
 
-    const result = await request.query(`
-      SELECT TOP 6000
-        cidade_st AS nome_cidade,
-        estado_st AS nome_estado
-      FROM [serv_product_be180].[bancoAtivosJoin_ft]
-      ${where}
-      GROUP BY cidade_st, estado_st
-      ORDER BY cidade_st
+    // Verifica se tabela de praças customizadas existe
+    const hasCustom = await pool.request().query(`
+      SELECT 1 AS existe FROM sys.tables t
+      JOIN sys.schemas s ON s.schema_id = t.schema_id
+      WHERE s.name = 'serv_product_be180' AND t.name = 'praca_canonica_dm'
+    `);
+
+    const customUnion = hasCustom.recordset.length
+      ? `UNION
+         SELECT UPPER(LTRIM(RTRIM(nome_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(uf_st))) AS nome_estado
+         FROM [serv_product_be180].[praca_canonica_dm]
+         WHERE delete_bl = 0`
+      : '';
+
+    const result = await req_.query(`
+      SELECT DISTINCT nome_cidade, nome_estado
+      FROM (
+        -- 1. IBGE (fonte principal — todos os municípios brasileiros)
+        SELECT UPPER(LTRIM(RTRIM(cidade_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(estado_st))) AS nome_estado
+        FROM [serv_product_be180].[cidadeIbge_dm]
+        WHERE cidade_st IS NOT NULL
+
+        UNION
+
+        -- 2. Banco de ativos legado (complementa praças com nomes customizados como "BARRA DA TIJUCA/RECREIO")
+        SELECT UPPER(LTRIM(RTRIM(cidade_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(estado_st))) AS nome_estado
+        FROM [serv_product_be180].[bancoAtivosJoin_ft]
+        WHERE valid_bl = 1 AND cidade_st IS NOT NULL
+
+        ${customUnion}
+      ) AS unificado
+      WHERE nome_cidade IS NOT NULL AND nome_cidade <> ''
+      ${searchFilter}
+      ORDER BY nome_cidade
     `);
 
     res.json(result.recordset.map(r => ({

--- a/handlers/pracas-admin.js
+++ b/handlers/pracas-admin.js
@@ -1,0 +1,180 @@
+const { sql, getPool } = require('./db');
+
+/**
+ * API de administração de praças canônicas.
+ *
+ * GET  ?mode=pendentes   — praças submetidas por exibidores que não constam no IBGE/legado
+ * GET  ?mode=list        — lista de praças customizadas cadastradas pelo admin
+ * POST op=criar          — cadastra nova praça customizada { nome_st, uf_st }
+ * POST op=criar-tabela   — garante que praca_canonica_dm existe (migration idempotente)
+ * DELETE ?pk=N           — soft-delete de praça customizada
+ */
+module.exports = async (req, res) => {
+  try {
+    const pool = await getPool();
+
+    // ── GET ───────────────────────────────────────────────────────────────────
+    if (req.method === 'GET') {
+      const mode   = String(req.query.mode || 'pendentes');
+      const search = (req.query.search || '').trim();
+
+      if (mode === 'pendentes') {
+        // Praças dos exibidores que não existem nem no IBGE nem no legado
+        const req_ = pool.request();
+        let searchWhere = '';
+        if (search) {
+          req_.input('search', sql.NVarChar, `%${search}%`);
+          searchWhere = 'AND (UPPER(i.praca_st) LIKE @search OR i.uf_st LIKE @search)';
+        }
+        const result = await req_.query(`
+          SELECT
+            UPPER(LTRIM(RTRIM(i.praca_st))) AS praca_st,
+            UPPER(LTRIM(RTRIM(i.uf_st)))    AS uf_st,
+            COUNT(DISTINCT i.lote_fk)        AS qtd_lotes,
+            COUNT(1)                         AS qtd_itens,
+            MAX(e.nome_st)                   AS exibidor_nome
+          FROM [serv_product_be180].[exibidor_inventario_item_dm] i
+          JOIN [serv_product_be180].[exibidor_inventario_upload_lote_dm] l
+            ON l.lote_pk = i.lote_fk
+          JOIN [serv_product_be180].[exibidor_dm] e
+            ON e.exibidor_pk = l.exibidor_fk
+          WHERE i.delete_bl = 0
+            AND i.praca_st IS NOT NULL
+            AND LTRIM(RTRIM(i.praca_st)) <> ''
+            ${searchWhere}
+            AND NOT EXISTS (
+              SELECT 1 FROM [serv_product_be180].[cidadeIbge_dm] c
+              WHERE UPPER(LTRIM(RTRIM(c.cidade_st))) = UPPER(LTRIM(RTRIM(i.praca_st)))
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM [serv_product_be180].[bancoAtivosJoin_ft] b
+              WHERE UPPER(LTRIM(RTRIM(b.cidade_st))) = UPPER(LTRIM(RTRIM(i.praca_st)))
+                AND b.valid_bl = 1
+            )
+          GROUP BY UPPER(LTRIM(RTRIM(i.praca_st))), UPPER(LTRIM(RTRIM(i.uf_st)))
+          ORDER BY qtd_itens DESC
+        `);
+        return res.json({ success: true, data: result.recordset });
+      }
+
+      if (mode === 'list') {
+        const hasTable = await pool.request().query(`
+          SELECT 1 AS ok FROM sys.tables t
+          JOIN sys.schemas s ON s.schema_id = t.schema_id
+          WHERE s.name = 'serv_product_be180' AND t.name = 'praca_canonica_dm'
+        `);
+        if (!hasTable.recordset.length) {
+          return res.json({ success: true, data: [] });
+        }
+        const req_ = pool.request();
+        let where = 'WHERE delete_bl = 0';
+        if (search) {
+          req_.input('search', sql.NVarChar, `%${search}%`);
+          where += ' AND (nome_st LIKE @search OR uf_st LIKE @search)';
+        }
+        const result = await req_.query(`
+          SELECT praca_pk, nome_st, uf_st, dataCriacao_dh, criadoPor_st
+          FROM [serv_product_be180].[praca_canonica_dm]
+          ${where}
+          ORDER BY nome_st
+        `);
+        return res.json({ success: true, data: result.recordset });
+      }
+
+      return res.status(400).json({ error: 'mode inválido. Use: pendentes | list' });
+    }
+
+    // ── POST ──────────────────────────────────────────────────────────────────
+    if (req.method === 'POST') {
+      const { op, nome_st, uf_st } = req.body || {};
+
+      // Garante que a tabela existe (migration idempotente)
+      if (op === 'criar-tabela') {
+        const hasTable = await pool.request().query(`
+          SELECT 1 AS ok FROM sys.tables t
+          JOIN sys.schemas s ON s.schema_id = t.schema_id
+          WHERE s.name = 'serv_product_be180' AND t.name = 'praca_canonica_dm'
+        `);
+        if (!hasTable.recordset.length) {
+          await pool.request().query(`
+            CREATE TABLE [serv_product_be180].[praca_canonica_dm] (
+              praca_pk       INT IDENTITY(1,1) PRIMARY KEY,
+              nome_st        NVARCHAR(200) NOT NULL,
+              uf_st          NVARCHAR(2)   NULL,
+              delete_bl      BIT           NOT NULL DEFAULT 0,
+              dataCriacao_dh DATETIME      NOT NULL DEFAULT GETDATE(),
+              criadoPor_st   NVARCHAR(255) NULL,
+              CONSTRAINT UQ_praca_canonica UNIQUE (nome_st, uf_st)
+            )
+          `);
+          return res.json({ success: true, created: true, message: 'Tabela praca_canonica_dm criada com sucesso.' });
+        }
+        return res.json({ success: true, created: false, message: 'Tabela já existe.' });
+      }
+
+      if (op === 'criar') {
+        const nome = String(nome_st || '').trim().toUpperCase();
+        const uf   = String(uf_st   || '').trim().toUpperCase();
+        if (!nome) return res.status(400).json({ error: 'nome_st é obrigatório' });
+
+        // Garante tabela
+        const hasTable = await pool.request().query(`
+          SELECT 1 AS ok FROM sys.tables t
+          JOIN sys.schemas s ON s.schema_id = t.schema_id
+          WHERE s.name = 'serv_product_be180' AND t.name = 'praca_canonica_dm'
+        `);
+        if (!hasTable.recordset.length) {
+          await pool.request().query(`
+            CREATE TABLE [serv_product_be180].[praca_canonica_dm] (
+              praca_pk       INT IDENTITY(1,1) PRIMARY KEY,
+              nome_st        NVARCHAR(200) NOT NULL,
+              uf_st          NVARCHAR(2)   NULL,
+              delete_bl      BIT           NOT NULL DEFAULT 0,
+              dataCriacao_dh DATETIME      NOT NULL DEFAULT GETDATE(),
+              criadoPor_st   NVARCHAR(255) NULL,
+              CONSTRAINT UQ_praca_canonica UNIQUE (nome_st, uf_st)
+            )
+          `);
+        }
+
+        const ins = await pool.request()
+          .input('nome', sql.NVarChar(200), nome)
+          .input('uf',   sql.NVarChar(2),   uf || null)
+          .input('who',  sql.NVarChar(255),  req.user?.email || null)
+          .query(`
+            MERGE [serv_product_be180].[praca_canonica_dm] AS tgt
+            USING (SELECT @nome AS nome_st, @uf AS uf_st) AS src
+              ON tgt.nome_st = src.nome_st AND tgt.uf_st = src.uf_st
+            WHEN MATCHED AND tgt.delete_bl = 1 THEN
+              UPDATE SET tgt.delete_bl = 0, tgt.dataCriacao_dh = GETDATE(), tgt.criadoPor_st = @who
+            WHEN NOT MATCHED THEN
+              INSERT (nome_st, uf_st, criadoPor_st) VALUES (@nome, @uf, @who);
+
+            SELECT TOP 1 praca_pk, nome_st, uf_st
+            FROM [serv_product_be180].[praca_canonica_dm]
+            WHERE nome_st = @nome AND (uf_st = @uf OR (@uf IS NULL AND uf_st IS NULL))
+          `);
+
+        return res.status(201).json({ success: true, praca: ins.recordset[0] });
+      }
+
+      return res.status(400).json({ error: 'op inválido. Use: criar | criar-tabela' });
+    }
+
+    // ── DELETE ────────────────────────────────────────────────────────────────
+    if (req.method === 'DELETE') {
+      const pk = Number(req.query.pk || 0);
+      if (!pk) return res.status(400).json({ error: 'pk é obrigatório' });
+      await pool.request()
+        .input('pk', sql.Int, pk)
+        .query(`UPDATE [serv_product_be180].[praca_canonica_dm] SET delete_bl = 1 WHERE praca_pk = @pk`);
+      return res.json({ success: true });
+    }
+
+    return res.status(405).json({ error: 'Método não permitido' });
+
+  } catch (err) {
+    console.error('[pracas-admin]', err.message);
+    return res.status(500).json({ error: 'Erro interno', message: err.message });
+  }
+};

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -445,6 +445,15 @@ export const Sidebar: React.FC<SidebarProps> = ({ menuReduzido, setMenuReduzido 
                     Gerenciar Perfis
                   </div>
                 </Link>
+                <Link to="/admin/pracas" className="block">
+                  <div className={`px-2 py-1.5 rounded transition-colors duration-200 text-sm ${
+                    location.pathname.startsWith("/admin/pracas")
+                      ? "text-[#ff4600] font-medium"
+                      : "text-[#3a3a3a] hover:bg-[#ededed]"
+                  }`}>
+                    Praças canônicas
+                  </div>
+                </Link>
               </div>
             )}
           </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ const AdminUsuarios          = lazy(() => import("./screens/Admin").then(m => ({
 const AdminPerfis            = lazy(() => import("./screens/Admin").then(m => ({ default: m.AdminPerfis })));
 const ExibidoresDashboard    = lazy(() => import("./screens/Admin").then(m => ({ default: m.ExibidoresDashboard })));
 const AdminInventarios       = lazy(() => import("./screens/AdminInventarios/AdminInventarios").then(m => ({ default: m.AdminInventarios })));
+const AdminPracas            = lazy(() => import("./screens/Admin").then(m => ({ default: m.AdminPracas })));
 const BlueprintDiligencia    = lazy(() => import("./screens/BlueprintDiligencia").then(m => ({ default: m.BlueprintDiligencia })));
 const DesignSystem           = lazy(() => import("./screens/DesignSystem").then(m => ({ default: m.DesignSystem })));
 const MapaDoProduto          = lazy(() => import("./screens/MapaDoProduto").then(m => ({ default: m.MapaDoProduto })));
@@ -228,6 +229,9 @@ root.render(
                 } />
                 <Route path="/admin/mapa-do-produto" element={
                   <ProtectedRoute internalOnly adminOnly><MapaDoProduto /></ProtectedRoute>
+                } />
+                <Route path="/admin/pracas" element={
+                  <ProtectedRoute internalOnly adminOnly><AdminPracas /></ProtectedRoute>
                 } />
 
                 <Route path="*" element={<div>Página não encontrada</div>} />

--- a/src/screens/Admin/Pracas/AdminPracas.tsx
+++ b/src/screens/Admin/Pracas/AdminPracas.tsx
@@ -1,0 +1,354 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import api from '../../../config/axios';
+import { Sidebar } from '../../../components/Sidebar/Sidebar';
+import { Topbar } from '../../../components/Topbar/Topbar';
+
+interface PracaPendente {
+  praca_st: string;
+  uf_st: string;
+  qtd_itens: number;
+  qtd_lotes: number;
+  exibidor_nome: string;
+}
+
+interface PracaCustom {
+  praca_pk: number;
+  nome_st: string;
+  uf_st: string;
+  dataCriacao_dh: string;
+  criadoPor_st: string;
+}
+
+const UF_LIST = [
+  'AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS',
+  'MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC',
+  'SP','SE','TO',
+];
+
+const inputCls = 'w-full h-9 px-3 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 transition-colors bg-white';
+const labelCls = 'block text-[10px] uppercase tracking-widest text-gray-400 font-semibold mb-1';
+
+export const AdminPracas: React.FC = () => {
+  const [menuReduzido, setMenuReduzido] = useState(false);
+  const [aba, setAba] = useState<'pendentes' | 'cadastradas'>('pendentes');
+
+  // ── Pendentes ────────────────────────────────────────────────────────────
+  const [pendentes, setPendentes]         = useState<PracaPendente[]>([]);
+  const [loadingPend, setLoadingPend]     = useState(false);
+  const [searchPend, setSearchPend]       = useState('');
+
+  // ── Cadastradas ──────────────────────────────────────────────────────────
+  const [cadastradas, setCadastradas]     = useState<PracaCustom[]>([]);
+  const [loadingCad, setLoadingCad]       = useState(false);
+  const [searchCad, setSearchCad]         = useState('');
+
+  // ── Formulário novo cadastro ─────────────────────────────────────────────
+  const [novoNome, setNovoNome]           = useState('');
+  const [novoUf, setNovoUf]               = useState('');
+  const [salvando, setSalvando]           = useState(false);
+  const [msgSucesso, setMsgSucesso]       = useState('');
+  const [msgErro, setMsgErro]             = useState('');
+
+  // ── Remoção ──────────────────────────────────────────────────────────────
+  const [removendo, setRemovendo]         = useState<number | null>(null);
+
+  const carregarPendentes = useCallback(async (search = '') => {
+    setLoadingPend(true);
+    try {
+      const r = await api.get('/pracas-admin', { params: { mode: 'pendentes', search: search || undefined } });
+      setPendentes(r.data.data || []);
+    } finally {
+      setLoadingPend(false);
+    }
+  }, []);
+
+  const carregarCadastradas = useCallback(async (search = '') => {
+    setLoadingCad(true);
+    try {
+      const r = await api.get('/pracas-admin', { params: { mode: 'list', search: search || undefined } });
+      setCadastradas(r.data.data || []);
+    } finally {
+      setLoadingCad(false);
+    }
+  }, []);
+
+  useEffect(() => { carregarPendentes(); carregarCadastradas(); }, [carregarPendentes, carregarCadastradas]);
+
+  const salvar = async (nome?: string, uf?: string) => {
+    const n = (nome ?? novoNome).trim().toUpperCase();
+    const u = (uf  ?? novoUf).trim().toUpperCase();
+    if (!n) { setMsgErro('Informe o nome da praça.'); return; }
+
+    setSalvando(true);
+    setMsgErro('');
+    setMsgSucesso('');
+    try {
+      await api.post('/pracas-admin', { op: 'criar', nome_st: n, uf_st: u || undefined });
+      setMsgSucesso(`Praça "${n}"${u ? ` (${u})` : ''} cadastrada com sucesso!`);
+      setNovoNome('');
+      setNovoUf('');
+      await Promise.all([carregarPendentes(searchPend), carregarCadastradas(searchCad)]);
+      setTimeout(() => setMsgSucesso(''), 4000);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      setMsgErro(err?.response?.data?.error || 'Erro ao salvar praça.');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const remover = async (pk: number) => {
+    setRemovendo(pk);
+    try {
+      await api.delete('/pracas-admin', { params: { pk } });
+      await carregarCadastradas(searchCad);
+    } finally {
+      setRemovendo(null);
+    }
+  };
+
+  const adicionarDaPendente = (p: PracaPendente) => {
+    salvar(p.praca_st, p.uf_st);
+  };
+
+  return (
+    <div className="min-h-screen bg-white flex font-sans">
+      <Sidebar menuReduzido={menuReduzido} setMenuReduzido={setMenuReduzido} />
+      <div className={`fixed top-0 z-40 h-screen w-px bg-[#c1c1c1] ${menuReduzido ? 'left-20' : 'left-64'}`} />
+      <div className={`flex-1 transition-all duration-300 min-h-screen ${menuReduzido ? 'ml-20' : 'ml-64'} flex flex-col`}>
+        <Topbar menuReduzido={menuReduzido} breadcrumb={{ items: [
+          { label: 'Admin' },
+          { label: 'Praças canônicas' },
+        ]}} />
+        <div className={`fixed top-[72px] z-30 h-[1px] bg-[#c1c1c1] ${menuReduzido ? 'left-20 w-[calc(100%-5rem)]' : 'left-64 w-[calc(100%-16rem)]'}`} />
+
+        <div className="flex-1 pt-24 pb-32 px-8 overflow-auto">
+          <div className="max-w-6xl mx-auto space-y-8">
+
+            {/* Cabeçalho */}
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.18em] text-[#ff4600] font-semibold mb-2">Admin</p>
+              <h1 className="text-3xl font-bold text-[#ff4600] uppercase tracking-wide">Praças Canônicas</h1>
+              <p className="text-gray-500 text-sm mt-1 max-w-2xl">
+                Gerencie a lista de praças disponíveis no dropdown de correção de inventário dos exibidores.
+                O sistema já inclui os 5.570 municípios do IBGE — aqui você cadastra praças customizadas
+                (ex: sub-regiões, bairros-praça) e visualiza praças pendentes enviadas por exibidores.
+              </p>
+            </div>
+
+            {/* Formulário de cadastro rápido */}
+            <div className="border border-gray-200 rounded-xl p-6 bg-gray-50/40">
+              <p className="text-sm font-semibold text-gray-800 mb-4">Cadastrar nova praça customizada</p>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <div className="flex-1">
+                  <label className={labelCls}>Nome da praça</label>
+                  <input
+                    type="text"
+                    className={inputCls}
+                    placeholder="Ex: BARRA DA TIJUCA/RECREIO"
+                    value={novoNome}
+                    onChange={(e) => setNovoNome(e.target.value.toUpperCase())}
+                    onKeyDown={(e) => e.key === 'Enter' && salvar()}
+                  />
+                </div>
+                <div className="w-28">
+                  <label className={labelCls}>UF</label>
+                  <select
+                    className={inputCls}
+                    value={novoUf}
+                    onChange={(e) => setNovoUf(e.target.value)}
+                  >
+                    <option value="">—</option>
+                    {UF_LIST.map((uf) => <option key={uf} value={uf}>{uf}</option>)}
+                  </select>
+                </div>
+                <div className="flex items-end">
+                  <button
+                    onClick={() => salvar()}
+                    disabled={salvando || !novoNome.trim()}
+                    className="h-9 px-5 rounded-lg bg-[#ff4600] hover:bg-[#e33d00] disabled:opacity-40 text-white text-sm font-semibold transition-all"
+                  >
+                    {salvando ? 'Salvando...' : 'Cadastrar'}
+                  </button>
+                </div>
+              </div>
+              {msgSucesso && <p className="mt-3 text-sm text-green-700 font-medium">{msgSucesso}</p>}
+              {msgErro    && <p className="mt-3 text-sm text-red-600">{msgErro}</p>}
+            </div>
+
+            {/* Abas */}
+            <div className="border-b border-gray-200">
+              <nav className="flex gap-6">
+                {([['pendentes', `Praças pendentes (${pendentes.length})`], ['cadastradas', `Cadastradas (${cadastradas.length})`]] as const).map(([id, label]) => (
+                  <button
+                    key={id}
+                    onClick={() => setAba(id)}
+                    className={`pb-3 text-sm font-medium border-b-2 transition-colors ${
+                      aba === id
+                        ? 'border-[#ff4600] text-[#ff4600]'
+                        : 'border-transparent text-gray-500 hover:text-gray-700'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </nav>
+            </div>
+
+            {/* ── ABA: PENDENTES ─────────────────────────────────────────────── */}
+            {aba === 'pendentes' && (
+              <div className="space-y-4">
+                <p className="text-sm text-gray-500">
+                  Praças enviadas por exibidores que <strong>não existem</strong> nos 5.570 municípios do IBGE
+                  nem no banco de ativos legado. Cadastre-as para que apareçam no dropdown de correção.
+                </p>
+
+                {/* Busca */}
+                <div className="flex gap-3">
+                  <div className="relative flex-1 max-w-sm">
+                    <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+                    </svg>
+                    <input
+                      type="text"
+                      className="w-full h-9 pl-9 pr-3 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400"
+                      placeholder="Filtrar por nome ou UF..."
+                      value={searchPend}
+                      onChange={(e) => setSearchPend(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && carregarPendentes(searchPend)}
+                    />
+                  </div>
+                  <button onClick={() => carregarPendentes(searchPend)}
+                    className="h-9 px-4 rounded-lg bg-gray-900 hover:bg-gray-700 text-white text-sm font-medium transition-colors">
+                    Buscar
+                  </button>
+                </div>
+
+                {loadingPend ? (
+                  <div className="flex items-center gap-3 py-12 text-gray-400">
+                    <div className="w-5 h-5 border-2 border-gray-200 border-t-[#ff4600] rounded-full animate-spin" />
+                    <span className="text-sm">Carregando...</span>
+                  </div>
+                ) : pendentes.length === 0 ? (
+                  <div className="text-center py-16 border border-dashed border-gray-200 rounded-xl">
+                    <p className="text-gray-400 text-sm">Nenhuma praça pendente encontrada.</p>
+                  </div>
+                ) : (
+                  <div className="border border-gray-200 rounded-xl overflow-hidden">
+                    <table className="w-full">
+                      <thead>
+                        <tr className="bg-gray-50 border-b border-gray-200">
+                          <th className="text-left px-5 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">Praça</th>
+                          <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">UF</th>
+                          <th className="text-right px-4 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">Itens</th>
+                          <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">Exibidor</th>
+                          <th className="px-4 py-3" />
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {pendentes.map((p) => (
+                          <tr key={`${p.praca_st}_${p.uf_st}`} className="hover:bg-gray-50 transition-colors">
+                            <td className="px-5 py-3 text-sm font-medium text-gray-800">{p.praca_st}</td>
+                            <td className="px-4 py-3 text-sm text-gray-500">{p.uf_st || '—'}</td>
+                            <td className="px-4 py-3 text-sm text-right text-gray-700 font-medium">{p.qtd_itens}</td>
+                            <td className="px-4 py-3 text-sm text-gray-500">{p.exibidor_nome}</td>
+                            <td className="px-4 py-3 text-right">
+                              <button
+                                onClick={() => adicionarDaPendente(p)}
+                                disabled={salvando}
+                                className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md bg-[#ff4600] hover:bg-[#e33d00] disabled:opacity-40 text-white text-[11px] font-semibold transition-all"
+                              >
+                                + Cadastrar
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── ABA: CADASTRADAS ───────────────────────────────────────────── */}
+            {aba === 'cadastradas' && (
+              <div className="space-y-4">
+                <p className="text-sm text-gray-500">
+                  Praças customizadas cadastradas manualmente. Estas aparecem no dropdown junto com os municípios do IBGE.
+                </p>
+
+                <div className="flex gap-3">
+                  <div className="relative flex-1 max-w-sm">
+                    <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+                    </svg>
+                    <input
+                      type="text"
+                      className="w-full h-9 pl-9 pr-3 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400"
+                      placeholder="Buscar praça..."
+                      value={searchCad}
+                      onChange={(e) => setSearchCad(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && carregarCadastradas(searchCad)}
+                    />
+                  </div>
+                  <button onClick={() => carregarCadastradas(searchCad)}
+                    className="h-9 px-4 rounded-lg bg-gray-900 hover:bg-gray-700 text-white text-sm font-medium transition-colors">
+                    Buscar
+                  </button>
+                </div>
+
+                {loadingCad ? (
+                  <div className="flex items-center gap-3 py-12 text-gray-400">
+                    <div className="w-5 h-5 border-2 border-gray-200 border-t-[#ff4600] rounded-full animate-spin" />
+                    <span className="text-sm">Carregando...</span>
+                  </div>
+                ) : cadastradas.length === 0 ? (
+                  <div className="text-center py-16 border border-dashed border-gray-200 rounded-xl">
+                    <p className="text-gray-400 text-sm">Nenhuma praça customizada cadastrada ainda.</p>
+                    <p className="text-gray-300 text-xs mt-1">Use o formulário acima ou a aba "Pendentes" para adicionar.</p>
+                  </div>
+                ) : (
+                  <div className="border border-gray-200 rounded-xl overflow-hidden">
+                    <table className="w-full">
+                      <thead>
+                        <tr className="bg-gray-50 border-b border-gray-200">
+                          <th className="text-left px-5 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">Praça</th>
+                          <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">UF</th>
+                          <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">Cadastrado por</th>
+                          <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-gray-400 font-semibold">Data</th>
+                          <th className="px-4 py-3" />
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {cadastradas.map((c) => (
+                          <tr key={c.praca_pk} className="hover:bg-gray-50 transition-colors">
+                            <td className="px-5 py-3 text-sm font-medium text-gray-800">{c.nome_st}</td>
+                            <td className="px-4 py-3 text-sm text-gray-500">{c.uf_st || '—'}</td>
+                            <td className="px-4 py-3 text-sm text-gray-500">{c.criadoPor_st || '—'}</td>
+                            <td className="px-4 py-3 text-sm text-gray-400">
+                              {c.dataCriacao_dh ? new Date(c.dataCriacao_dh).toLocaleDateString('pt-BR') : '—'}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              <button
+                                onClick={() => remover(c.praca_pk)}
+                                disabled={removendo === c.praca_pk}
+                                className="h-7 px-3 rounded-md border border-red-200 hover:bg-red-50 text-red-500 text-[11px] font-medium transition-colors disabled:opacity-40"
+                              >
+                                {removendo === c.praca_pk ? 'Removendo...' : 'Remover'}
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/Admin/Pracas/AdminPracas.tsx
+++ b/src/screens/Admin/Pracas/AdminPracas.tsx
@@ -112,18 +112,19 @@ export const AdminPracas: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-white flex font-sans">
+    <div className="min-h-screen bg-[#fafafa] flex font-sans">
       <Sidebar menuReduzido={menuReduzido} setMenuReduzido={setMenuReduzido} />
+
       <div className={`fixed top-0 z-40 h-screen w-px bg-[#c1c1c1] ${menuReduzido ? 'left-20' : 'left-64'}`} />
-      <div className={`flex-1 transition-all duration-300 min-h-screen ${menuReduzido ? 'ml-20' : 'ml-64'} flex flex-col`}>
-        <Topbar menuReduzido={menuReduzido} breadcrumb={{ items: [
-          { label: 'Admin' },
-          { label: 'Praças canônicas' },
-        ]}} />
+
+      <div className={`flex-1 transition-all duration-300 min-h-screen w-full ${menuReduzido ? 'ml-20' : 'ml-64'} flex flex-col`}>
+        <Topbar menuReduzido={menuReduzido} />
+
         <div className={`fixed top-[72px] z-30 h-[1px] bg-[#c1c1c1] ${menuReduzido ? 'left-20 w-[calc(100%-5rem)]' : 'left-64 w-[calc(100%-16rem)]'}`} />
 
-        <div className="flex-1 pt-24 pb-32 px-8 overflow-auto">
-          <div className="max-w-6xl mx-auto space-y-8">
+        <div className="flex-1 pt-24 pb-32 overflow-auto">
+        <main className="w-full px-10 xl:px-14 2xl:px-20">
+          <div className="space-y-8">
 
             {/* Cabeçalho */}
             <div>
@@ -347,6 +348,7 @@ export const AdminPracas: React.FC = () => {
             )}
 
           </div>
+        </main>
         </div>
       </div>
     </div>

--- a/src/screens/Admin/index.ts
+++ b/src/screens/Admin/index.ts
@@ -1,3 +1,4 @@
 export { AdminUsuarios } from './Usuarios/AdminUsuarios';
 export { AdminPerfis } from './Perfis/AdminPerfis';
 export { ExibidoresDashboard } from './ExibidoresDashboard/ExibidoresDashboard';
+export { AdminPracas } from './Pracas/AdminPracas';

--- a/vercel.json
+++ b/vercel.json
@@ -126,6 +126,7 @@
     { "source": "/api/verificar-acesso", "destination": "/api/admin?action=verificar-acesso" },
     { "source": "/api/admin-inventario-analise", "destination": "/api/admin?action=inventario-analise" },
     { "source": "/api/exibidores-dashboard", "destination": "/api/admin?action=exibidores-dashboard" },
+    { "source": "/api/pracas-admin", "destination": "/api/admin?action=pracas-admin" },
 
     { "source": "/api/ocorrencia-criar", "destination": "/api/ocorrencia?action=criar" },
 


### PR DESCRIPTION
feat: admin de praças canônicas + dropdown com todos os municípios brasileiros

Problema O dropdown de correção de praça no painel de análise de inventário só exibia ~810 cidades do banco de ativos legado. Praças como PARACAMBI, SAQUAREMA, CATANDUVA (enviadas por exibidores) não apareciam, impedindo que a Isra conseguisse corrigir a informação.

O que foi feito

cidades-praca.js — UNION de cidadeIbge_dm (5.570 municípios) + bancoAtivosJoin_ft + praças customizadas. Dropdown passou de ~810 para 5.622 cidades
pracas-admin.js — novo handler com GET (pendentes/lista), POST (criar) e DELETE (remover). Cria a tabela praca_canonica_dm via migration idempotente na primeira execução
AdminPracas.tsx — nova tela em /admin/pracas com duas abas: Praças pendentes (enviadas por exibidores fora do IBGE, com botão "+ Cadastrar") e Cadastradas (praças customizadas com remoção). Formulário de cadastro manual disponível no topo
Rota registrada no vercel.json, api/admin.js e link adicionado na Sidebar em Administração
Critério de aceitação A Isra consegue escolher qualquer cidade padrão do Brasil no dropdown — e cadastrar praças customizadas (sub-regiões, bairros-praça) pelo painel admin.