### PR TITLE
Feat/indoor faces por semana

### DIFF
--- a/handlers/indoor-salvar.js
+++ b/handlers/indoor-salvar.js
@@ -69,7 +69,6 @@ module.exports = async (req, res) => {
       .input('planoMidiaGrupo_pk', sql.Int,                planoMidiaGrupo_pk)
       .input('report_pk',          sql.Int,                planoMidiaGrupo_pk)
       .input('semanas',            sql.Int,                numSemanas)
-      .input('praca_st',           sql.NVarChar(255),      praca)
       .execute(`[${S}].[sp_planoMidiaIndoorInsert]`);
 
     const row = result.recordset?.[0];

--- a/handlers/indoor-salvar.js
+++ b/handlers/indoor-salvar.js
@@ -58,6 +58,9 @@ module.exports = async (req, res) => {
       localidades:         Array.isArray(l.localidades)
         ? l.localidades.map((v) => Number(v) || 0)
         : Array(12).fill(0),
+      faces:               Array.isArray(l.faces)
+        ? l.faces.map((v) => Number(v) || 1)
+        : Array(12).fill(1),
     }));
 
     const result = await pool

--- a/ongoing/15_SP_planoMidiaIndoorInsert.sql
+++ b/ongoing/15_SP_planoMidiaIndoorInsert.sql
@@ -29,7 +29,7 @@ BEGIN
     IF @praca_st IS NULL
         SET @praca_st = (SELECT TOP 1 JSON_VALUE([value], '$.praca_st') FROM OPENJSON(@recordsJson));
 
-    DECLARE @linhas TABLE (pk INT, ord INT, localidades NVARCHAR(MAX));
+    DECLARE @linhas TABLE (pk INT, ord INT, localidades NVARCHAR(MAX), faces NVARCHAR(MAX));
 
     BEGIN TRAN;
 
@@ -47,14 +47,14 @@ BEGIN
        AND [praca_st] = @praca_st;
 
     -- 1) linhas de ambiente. MERGE (ON 1=0 -> sempre INSERT) para o OUTPUT capturar
-    --    inserted.pk JUNTO com a ordem/localidades da origem (mapeamento ord<->pk set-based).
+    --    inserted.pk JUNTO com a ordem/localidades/faces da origem (mapeamento ord<->pk set-based).
     MERGE INTO [serv_product_be180].[planoMidiaIndoor_ft] AS tgt
     USING (
         SELECT
             j.[key] AS ord,
             x.[praca_st], x.[ambiente_st], x.[indoorEspecifico_st], x.[tamanhoFormato_st],
             x.[circulacao_st], x.[tipo_st], x.[passantesManual_vl], x.[insercoesPorSlot_vl],
-            x.[slots_vl], x.[localidades]
+            x.[slots_vl], x.[localidades], x.[faces]
         FROM OPENJSON(@recordsJson) j
         CROSS APPLY OPENJSON(j.[value]) WITH (
             praca_st            NVARCHAR(255) '$.praca_st',
@@ -66,7 +66,8 @@ BEGIN
             passantesManual_vl  FLOAT         '$.passantesManual_vl',
             insercoesPorSlot_vl INT           '$.insercoesPorSlot_vl',
             slots_vl            INT           '$.slots_vl',
-            localidades         NVARCHAR(MAX) '$.localidades' AS JSON
+            localidades         NVARCHAR(MAX) '$.localidades' AS JSON,
+            faces               NVARCHAR(MAX) '$.faces'       AS JSON
         ) x
     ) AS src
     ON (1 = 0)
@@ -78,14 +79,19 @@ BEGIN
                 NULLIF(src.[indoorEspecifico_st], N''), src.[tamanhoFormato_st], src.[circulacao_st],
                 ISNULL(NULLIF(src.[tipo_st], N''), N'Estático'), src.[passantesManual_vl],
                 src.[insercoesPorSlot_vl], src.[slots_vl])
-    OUTPUT inserted.[pk], src.ord, src.[localidades] INTO @linhas([pk], [ord], [localidades]);
+    OUTPUT inserted.[pk], src.ord, src.[localidades], src.[faces]
+      INTO @linhas([pk], [ord], [localidades], [faces]);
 
-    -- 2) localidades por semana (W1..12) por linha; semanas > @semanas viram 0
-    INSERT INTO [serv_product_be180].[planoMidiaIndoorSemana_ft] ([linha_pk], [semana_vl], [localidades_vl])
+    -- 2) localidades + faces por semana (W1..12) por linha; semanas > @semanas viram 0/1
+    INSERT INTO [serv_product_be180].[planoMidiaIndoorSemana_ft]
+           ([linha_pk], [semana_vl], [localidades_vl], [faces_vl])
     SELECT L.[pk], n.semana,
            CASE WHEN n.semana <= @semanas
                 THEN ISNULL(TRY_CONVERT(INT, JSON_VALUE(L.[localidades], CONCAT('$[', n.semana - 1, ']'))), 0)
-                ELSE 0 END
+                ELSE 0 END,
+           CASE WHEN n.semana <= @semanas
+                THEN ISNULL(TRY_CONVERT(INT, JSON_VALUE(L.[faces], CONCAT('$[', n.semana - 1, ']'))), 1)
+                ELSE 1 END
     FROM @linhas L
     CROSS JOIN (VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12)) n(semana);
 

--- a/ongoing/15_SP_planoMidiaIndoorInsert.sql
+++ b/ongoing/15_SP_planoMidiaIndoorInsert.sql
@@ -16,35 +16,27 @@ CREATE OR ALTER PROCEDURE [serv_product_be180].[sp_planoMidiaIndoorInsert]
     @recordsJson        NVARCHAR(MAX),       -- array de linhas (1 por ambiente) — shape no doc integration/02
     @planoMidiaGrupo_pk INT,                 -- o roteiro
     @report_pk          INT = NULL,          -- D1: default = @planoMidiaGrupo_pk (1 report por roteiro)
-    @semanas            INT = 12,            -- nº de semanas ativas (W1..N); semanas > N viram 0
-    @praca_st           NVARCHAR(255) = NULL -- praça sendo (re)salva; NULL = limpa TODAS (legado)
+    @semanas            INT = 12             -- nº de semanas ativas (W1..N); semanas > N viram 0/1
 AS
 BEGIN
     SET NOCOUNT ON;
     SET XACT_ABORT ON;
 
-    IF @report_pk IS NULL SET @report_pk = @planoMidiaGrupo_pk;                 -- D1
+    IF @report_pk IS NULL SET @report_pk = @planoMidiaGrupo_pk;
     SET @semanas = CASE WHEN @semanas BETWEEN 1 AND 12 THEN @semanas ELSE 12 END;
-    -- Se não informado, extrai a praça do primeiro registro do JSON
-    IF @praca_st IS NULL
-        SET @praca_st = (SELECT TOP 1 JSON_VALUE([value], '$.praca_st') FROM OPENJSON(@recordsJson));
 
+    -- +faces: capturamos o array de faces junto com o de localidades
     DECLARE @linhas TABLE (pk INT, ord INT, localidades NVARCHAR(MAX), faces NVARCHAR(MAX));
 
     BEGIN TRAN;
 
-    -- (D6 idempotência) substitui APENAS os registros da praça atual neste roteiro/report
     DELETE w
       FROM [serv_product_be180].[planoMidiaIndoorSemana_ft] w
       JOIN [serv_product_be180].[planoMidiaIndoor_ft] l ON l.[pk] = w.[linha_pk]
-     WHERE l.[planoMidiaGrupo_pk] = @planoMidiaGrupo_pk
-       AND l.[report_pk] = @report_pk
-       AND l.[praca_st] = @praca_st;
+     WHERE l.[planoMidiaGrupo_pk] = @planoMidiaGrupo_pk AND l.[report_pk] = @report_pk;
 
     DELETE FROM [serv_product_be180].[planoMidiaIndoor_ft]
-     WHERE [planoMidiaGrupo_pk] = @planoMidiaGrupo_pk
-       AND [report_pk] = @report_pk
-       AND [praca_st] = @praca_st;
+     WHERE [planoMidiaGrupo_pk] = @planoMidiaGrupo_pk AND [report_pk] = @report_pk;
 
     -- 1) linhas de ambiente. MERGE (ON 1=0 -> sempre INSERT) para o OUTPUT capturar
     --    inserted.pk JUNTO com a ordem/localidades/faces da origem (mapeamento ord<->pk set-based).
@@ -67,7 +59,7 @@ BEGIN
             insercoesPorSlot_vl INT           '$.insercoesPorSlot_vl',
             slots_vl            INT           '$.slots_vl',
             localidades         NVARCHAR(MAX) '$.localidades' AS JSON,
-            faces               NVARCHAR(MAX) '$.faces'       AS JSON
+            faces               NVARCHAR(MAX) '$.faces'       AS JSON   -- +faces
         ) x
     ) AS src
     ON (1 = 0)
@@ -82,15 +74,15 @@ BEGIN
     OUTPUT inserted.[pk], src.ord, src.[localidades], src.[faces]
       INTO @linhas([pk], [ord], [localidades], [faces]);
 
-    -- 2) localidades + faces por semana (W1..12) por linha; semanas > @semanas viram 0/1
-    INSERT INTO [serv_product_be180].[planoMidiaIndoorSemana_ft]
-           ([linha_pk], [semana_vl], [localidades_vl], [faces_vl])
+    -- 2) localidades + faces por semana (W1..12). semanas > @semanas -> localidades 0 / faces 1.
+    --    faces ausente/inválido -> 1 (default). faces só pesa quando há frequência (localidades > 0).
+    INSERT INTO [serv_product_be180].[planoMidiaIndoorSemana_ft] ([linha_pk], [semana_vl], [localidades_vl], [faces_vl])
     SELECT L.[pk], n.semana,
            CASE WHEN n.semana <= @semanas
                 THEN ISNULL(TRY_CONVERT(INT, JSON_VALUE(L.[localidades], CONCAT('$[', n.semana - 1, ']'))), 0)
                 ELSE 0 END,
            CASE WHEN n.semana <= @semanas
-                THEN ISNULL(TRY_CONVERT(INT, JSON_VALUE(L.[faces], CONCAT('$[', n.semana - 1, ']'))), 1)
+                THEN ISNULL(NULLIF(TRY_CONVERT(INT, JSON_VALUE(L.[faces], CONCAT('$[', n.semana - 1, ']'))), 0), 1)
                 ELSE 1 END
     FROM @linhas L
     CROSS JOIN (VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12)) n(semana);

--- a/src/components/ConfigurarIndoor/AmbienteRowIndoor.tsx
+++ b/src/components/ConfigurarIndoor/AmbienteRowIndoor.tsx
@@ -35,6 +35,7 @@ export interface IndoorLinha {
   slots: string;
   totalInsOverride: string;
   locs: string[];
+  faces: string[];
 }
 
 export const emptyIndoorLinha = (): IndoorLinha => ({
@@ -47,7 +48,8 @@ export const emptyIndoorLinha = (): IndoorLinha => ({
   insercoesPorSlot: '',
   slots: '',
   totalInsOverride: '',
-  locs: Array.from({ length: 12 }, () => ''),
+  locs:  Array.from({ length: 12 }, () => ''),
+  faces: Array.from({ length: 12 }, () => '1'),
 });
 
 /* ─── VenueCombobox ─────────────────────────────────────────────── */
@@ -171,7 +173,8 @@ interface Props {
 }
 
 export default function AmbienteRowIndoor({ idx, dims, linha, semanas, praca, onChange, onRemove }: Props) {
-  const [padrao, setPadrao] = useState('');
+  const [padrao, setPadrao]           = useState('');
+  const [padraoFaces, setPadraoFaces] = useState('1');
 
   const amb = dims.ambientes.find((a) => a.nome === linha.ambiente);
   const hasEspecificos = !!amb?.hasEspecificos;
@@ -214,6 +217,16 @@ export default function AmbienteRowIndoor({ idx, dims, linha, semanas, praca, on
     const arr = [...linha.locs];
     for (let i = 0; i < semanas; i++) arr[i] = padrao;
     onChange({ ...linha, locs: arr });
+  };
+  const setFace = (w: number, v: string) => {
+    const arr = [...linha.faces];
+    arr[w] = v;
+    onChange({ ...linha, faces: arr });
+  };
+  const aplicarPadraoFaces = () => {
+    const arr = [...linha.faces];
+    for (let i = 0; i < semanas; i++) arr[i] = padraoFaces;
+    onChange({ ...linha, faces: arr });
   };
 
   const handleVenueChange = (nomeVenue: string) => {
@@ -399,7 +412,7 @@ export default function AmbienteRowIndoor({ idx, dims, linha, semanas, praca, on
           {/* Localidades por semana */}
           <div className="mt-3 pt-3 border-t border-gray-100">
             <div className="flex items-center justify-between mb-2 gap-3 flex-wrap">
-              <span className={lbl + ' mb-0'}>Localidades/semana (faces) · W1–W{semanas}</span>
+              <span className={lbl + ' mb-0'}>Localidades/semana · W1–W{semanas}</span>
               <div className="flex items-center gap-1.5">
                 <input
                   type="number"
@@ -425,6 +438,42 @@ export default function AmbienteRowIndoor({ idx, dims, linha, semanas, praca, on
                     type="number"
                     value={linha.locs[w] ?? ''}
                     onChange={(e) => setLoc(w, e.target.value)}
+                    className="w-full rounded border border-gray-200 px-0.5 py-1 text-xs text-center tabular-nums focus:border-[#ff4600] focus:outline-none"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Faces por semana */}
+          <div className="mt-3 pt-3 border-t border-gray-100">
+            <div className="flex items-center justify-between mb-2 gap-3 flex-wrap">
+              <span className={lbl + ' mb-0'}>Faces/semana · W1–W{semanas}</span>
+              <div className="flex items-center gap-1.5">
+                <input
+                  type="number"
+                  value={padraoFaces}
+                  onChange={(e) => setPadraoFaces(e.target.value)}
+                  placeholder="1"
+                  className="w-20 rounded border border-gray-200 px-2 py-1 text-xs text-center tabular-nums focus:border-[#ff4600] focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={aplicarPadraoFaces}
+                  className="rounded border border-gray-200 text-gray-500 px-2 py-1 text-xs hover:border-[#ff4600] hover:text-[#ff4600]"
+                >
+                  Aplicar
+                </button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {Array.from({ length: semanas }, (_, w) => (
+                <div key={w} className="w-[46px]">
+                  <div className="text-[9px] text-gray-400 text-center mb-0.5">W{w + 1}</div>
+                  <input
+                    type="number"
+                    value={linha.faces[w] ?? '1'}
+                    onChange={(e) => setFace(w, e.target.value)}
                     className="w-full rounded border border-gray-200 px-0.5 py-1 text-xs text-center tabular-nums focus:border-[#ff4600] focus:outline-none"
                   />
                 </div>

--- a/src/components/ConfigurarIndoor/ConfigurarIndoor.tsx
+++ b/src/components/ConfigurarIndoor/ConfigurarIndoor.tsx
@@ -134,6 +134,7 @@ export default function ConfigurarIndoor({
           insercoesPorSlot: l.insercoesPorSlot !== '' ? Number(l.insercoesPorSlot) : null,
           slots: l.slots !== '' ? Number(l.slots) : null,
           localidades: l.locs.map((v) => Number(v) || 0),
+          faces:       l.faces.map((v) => Number(v) || 1),
         })),
       };
 


### PR DESCRIPTION
O que muda
Adiciona faces como grandeza independente de localidades no configurador indoor (Aba 5). A frequência total indoor/consolidada passa a ser calculada como média ponderada por faces (metodologia Simone).

Mudanças no frontend
AmbienteRowIndoor.tsx

Interface IndoorLinha: novo campo faces: string[]
emptyIndoorLinha: inicializa faces com default '1' em todas as 12 semanas
Estado padraoFaces + handlers setFace / aplicarPadraoFaces (espelham exatamente setLoc / aplicarPadrao)
Label do bloco de localidades: remove o (faces) — agora é controle próprio
Novo bloco "Faces/semana · W1–Wn" logo abaixo de localidades, com campo padrão, botão Aplicar e inputs individuais por semana (default 1)
ConfigurarIndoor.tsx

Payload enviado à API inclui faces: l.faces.map((v) => Number(v) || 1)
Mudanças no backend
handlers/indoor-salvar.js

Repassa faces no JSON da SP (default Array(12).fill(1))
Fix: remove .input('praca_st') que a SP não declara — era a causa do erro too many arguments (error 8144)
ongoing/15_SP_planoMidiaIndoorInsert.sql

Sincronizado com a definição atual em produção: sem @praca_st, DELETE sem filtro de praça, ISNULL/NULLIF correto para faces_vl
Contrato com o banco
A SP já está deployada em produção com suporte a $.faces. O app agora envia o campo corretamente — nenhuma ação adicional no banco é necessária.