### PR TITLE
fix(aba3): corrigir praças duplicadas por acentuação no dropdown

### DIFF
--- a/handlers/cidades-praca.js
+++ b/handlers/cidades-praca.js
@@ -5,9 +5,11 @@ const { sql, getPool } = require('./db');
  *
  * Retorna lista canônica de praças para uso em dropdowns.
  * Fonte: UNION de:
- *  1. [cidadeIbge_dm]        — todos os 5570 municípios brasileiros (IBGE)
- *  2. [bancoAtivosJoin_ft]   — cidades do banco de ativos legado (fallback/complemento)
- *  3. [praca_canonica_dm]    — praças customizadas cadastradas pelo admin (se a tabela existir)
+ *  1. [bancoAtivosJoin_ft]   — cidades do banco de ativos legado OOH (nomes com acentos corretos)
+ *  2. [praca_canonica_dm]    — praças customizadas cadastradas pelo admin (se a tabela existir)
+ *
+ * Nota: [cidadeIbge_dm] foi removido temporariamente pois a tabela foi importada sem acentos.
+ * Reativar após re-importação com encoding correto (nvarchar + UTF-8/Latin1).
  *
  * Query param: search (opcional) — filtra por nome ou UF
  */
@@ -34,31 +36,38 @@ module.exports = async (req, res) => {
       WHERE s.name = 'serv_product_be180' AND t.name = 'praca_canonica_dm'
     `);
 
+    // Praças customizadas têm maior prioridade (0), depois legado OOH (1, com acentos corretos).
+    // IBGE foi removido por ter dados sem acento — re-importar com nvarchar/encoding correto
+    // antes de reativar.
+    // ROW_NUMBER com COLLATE CI_AI elimina duplicatas por acento/case dentro do legado.
     const customUnion = hasCustom.recordset.length
-      ? `UNION
-         SELECT UPPER(LTRIM(RTRIM(nome_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(uf_st))) AS nome_estado
+      ? `UNION ALL
+         SELECT UPPER(LTRIM(RTRIM(nome_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(uf_st))) AS nome_estado, 0 AS prioridade
          FROM [serv_product_be180].[praca_canonica_dm]
          WHERE delete_bl = 0`
       : '';
 
     const result = await req_.query(`
-      SELECT DISTINCT nome_cidade, nome_estado
+      SELECT nome_cidade, nome_estado
       FROM (
-        -- 1. IBGE (fonte principal — todos os municípios brasileiros)
-        SELECT UPPER(LTRIM(RTRIM(cidade_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(estado_st))) AS nome_estado
-        FROM [serv_product_be180].[cidadeIbge_dm]
-        WHERE cidade_st IS NOT NULL
+        SELECT
+          nome_cidade,
+          nome_estado,
+          ROW_NUMBER() OVER (
+            PARTITION BY nome_cidade COLLATE Latin1_General_CI_AI
+            ORDER BY prioridade ASC
+          ) AS rn
+        FROM (
+          -- 1. Banco de ativos legado OOH (nomes corretos com acentos: "SÃO PAULO", "BARRA DA TIJUCA/RECREIO" etc.)
+          SELECT UPPER(LTRIM(RTRIM(cidade_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(estado_st))) AS nome_estado, 1 AS prioridade
+          FROM [serv_product_be180].[bancoAtivosJoin_ft]
+          WHERE valid_bl = 1 AND cidade_st IS NOT NULL
 
-        UNION
-
-        -- 2. Banco de ativos legado (complementa praças com nomes customizados como "BARRA DA TIJUCA/RECREIO")
-        SELECT UPPER(LTRIM(RTRIM(cidade_st))) AS nome_cidade, UPPER(LTRIM(RTRIM(estado_st))) AS nome_estado
-        FROM [serv_product_be180].[bancoAtivosJoin_ft]
-        WHERE valid_bl = 1 AND cidade_st IS NOT NULL
-
-        ${customUnion}
-      ) AS unificado
-      WHERE nome_cidade IS NOT NULL AND nome_cidade <> ''
+          ${customUnion}
+        ) AS todas
+        WHERE nome_cidade IS NOT NULL AND nome_cidade <> ''
+      ) AS ranked
+      WHERE rn = 1
       ${searchFilter}
       ORDER BY nome_cidade
     `);

--- a/src/components/ImportarPlanoMidia/ImportarPlanoMidia.tsx
+++ b/src/components/ImportarPlanoMidia/ImportarPlanoMidia.tsx
@@ -54,12 +54,17 @@ export const ImportarPlanoMidia: React.FC<ImportarPlanoMidiaProps> = ({
   const willSkipCount = useMemo(() => parsedRows.length - willInsertCount, [parsedRows, willInsertCount]);
 
   const pracasUnicas = useMemo(() => {
-    const set = new Set<string>();
+    const normPraca = (s: string) =>
+      s.toUpperCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const seen = new Set<string>();
+    const lista: string[] = [];
     parsedRows.forEach((r) => {
       const p = r.praca_st as string | undefined;
-      if (p?.trim()) set.add(p.trim());
+      if (!p?.trim()) return;
+      const key = normPraca(p.trim());
+      if (!seen.has(key)) { seen.add(key); lista.push(p.trim()); }
     });
-    return [...set].sort();
+    return lista.sort();
   }, [parsedRows]);
 
   const previewRows = useMemo(() => parsedRows.slice(0, 5), [parsedRows]);

--- a/src/screens/CriarRoteiro/CriarRoteiro.tsx
+++ b/src/screens/CriarRoteiro/CriarRoteiro.tsx
@@ -485,8 +485,17 @@ export const CriarRoteiro: React.FC = () => {
       try {
         setLoadingCidades(true);
         const response = await axios.get('/cidades-praca');
-        setCidades(response.data);
-        setCidadesFiltradas(response.data);
+        const normStr = (s: string) =>
+          (s || '').toUpperCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/\s+/g, ' ');
+        const seen = new Set<string>();
+        const cidadesDedup = (response.data as Cidade[]).filter((c) => {
+          const key = `${normStr(c.nome_cidade)}|${normStr(c.nome_estado)}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+        setCidades(cidadesDedup);
+        setCidadesFiltradas(cidadesDedup);
       } catch (error) {
         console.error('Erro ao carregar cidades:', error);
       } finally {
@@ -507,16 +516,9 @@ export const CriarRoteiro: React.FC = () => {
   }, []);
 
   const getCidadeIdKey = React.useCallback((cidade: Cidade) => {
-    const rawId = cidade?.id_cidade;
-    if (rawId !== undefined && rawId !== null && String(rawId).trim() !== '') {
-      return String(rawId).trim();
-    }
-    return `${cidade.nome_cidade}|${cidade.nome_estado}`
-      .toUpperCase()
-      .trim()
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .replace(/\s+/g, ' ');
+    const norm = (s: string) =>
+      (s || '').toUpperCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/\s+/g, ' ');
+    return `${norm(cidade.nome_cidade)}|${norm(cidade.nome_estado)}`;
   }, []);
 
   // Filtrar cidades baseado na busca
@@ -661,9 +663,16 @@ export const CriarRoteiro: React.FC = () => {
     if (!pendingPracaNomes.length || !cidades.length) return;
     const normalizeName = (s: string) =>
       s.toUpperCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const seen = new Set<string>();
     const detectadas = pendingPracaNomes
       .map((nome) => cidades.find((c) => normalizeName(c.nome_cidade) === normalizeName(nome)))
-      .filter((c): c is typeof cidades[0] => c !== undefined);
+      .filter((c): c is typeof cidades[0] => c !== undefined)
+      .filter((c) => {
+        const key = `${normalizeName(c.nome_cidade)}|${normalizeName(c.nome_estado || '')}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
     if (detectadas.length > 0) {
       setCidadesSelecionadas(detectadas);
       setCidadesSalvas(detectadas);
@@ -681,9 +690,16 @@ export const CriarRoteiro: React.FC = () => {
     }
     const normalizeName = (s: string) =>
       s.toUpperCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const seen = new Set<string>();
     const detectadas = pracaNomes
       .map((nome) => cidades.find((c) => normalizeName(c.nome_cidade) === normalizeName(nome)))
-      .filter((c): c is typeof cidades[0] => c !== undefined);
+      .filter((c): c is typeof cidades[0] => c !== undefined)
+      .filter((c) => {
+        const key = `${normalizeName(c.nome_cidade)}|${normalizeName(c.nome_estado || '')}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
     if (detectadas.length > 0) {
       setCidadesSelecionadas(detectadas);
       setCidadesSalvas(detectadas);

--- a/src/utils/parsePlanoOohExcel.ts
+++ b/src/utils/parsePlanoOohExcel.ts
@@ -325,7 +325,17 @@ export async function parsePlanoOohExcel(file: File): Promise<ParsePlanoOohResul
 
   if (rows.length === 0) throw new Error('Nenhuma linha de dados encontrada na aba OOH.');
 
-  const pracasUnicas = [...new Set(rows.map((r) => r.praca_st as string).filter(Boolean))].sort();
+  const normPraca = (s: string) =>
+    s.toUpperCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const seenPracas = new Set<string>();
+  const pracasUnicas: string[] = [];
+  for (const r of rows) {
+    const p = r.praca_st as string | undefined;
+    if (!p?.trim()) continue;
+    const key = normPraca(p.trim());
+    if (!seenPracas.has(key)) { seenPracas.add(key); pracasUnicas.push(p.trim()); }
+  }
+  pracasUnicas.sort();
   const dates = rows.map((r) => r.inicio_dt as string).filter(Boolean).sort();
   const campanhas = [...new Set(rows.map((r) => r.campanha_st as string).filter(Boolean))];
 


### PR DESCRIPTION
Commit de hoje adicionou cidadeIbge_dm via UNION ao cidades-praca.js. O DISTINCT do SQL Server é accent-sensitive na collation padrão, então "SÃO PAULO" (legado) e "SAO PAULO" (IBGE) viravam dois registros distintos. No frontend, getCidadeIdKey usava o id_cidade literal, então a dedup por seleção também não reconhecia as variantes como a mesma praça.

- handlers/cidades-praca.js: substitui UNION+DISTINCT por UNION ALL + ROW_NUMBER OVER (PARTITION BY COLLATE Latin1_General_CI_AI ORDER BY prioridade); remove cidadeIbge_dm temporariamente pois a tabela foi importada sem acentos (SAO PAULO DAS MISSOES em vez de SÃO PAULO DAS MISSÕES)
- CriarRoteiro.tsx: getCidadeIdKey sempre normaliza (remove acentos, uppercase) em vez de retornar id_cidade literal; dedup ao carregar cidades da API; handlePracasDetectadas e efeito pendingPracaNomes deduplicam por chave normalizada após o map() para evitar a mesma praça entrar 2x via Excel
- parsePlanoOohExcel.ts: pracasUnicas deduplica por nome normalizado
- ImportarPlanoMidia.tsx: idem para o useMemo de pracasUnicas